### PR TITLE
feat(cli)!: add run queue, worker, and execution traces

### DIFF
--- a/.docs/ai-interface.md
+++ b/.docs/ai-interface.md
@@ -21,6 +21,99 @@ The user remains the gatekeeper at the OS level (file permissions, sudo,
 network). Omakure does not attempt to sandbox what the underlying script
 does.
 
+## Storage privacy contract
+
+`<workspace>/.history/runs.sqlite` is **private internal storage of the
+omakure CLI**. Scripts, agents, and orchestrators must never open this
+file directly — neither for reads nor for writes. The only legitimate
+access paths are the documented verbs:
+
+- writes: `omakure run`, `omakure queue add|cancel|dead-letter`,
+  `omakure queue worker`, `omakure trace`
+- reads: `omakure history list|show|stats|traces`, `omakure queue stats`
+
+This is an architectural rule, not a soft convention. Every code path
+in the omakure binary that touches `runs.sqlite` lives in `src/runs.rs`
+and is the only writer in the codebase. Scripts launched by
+`omakure run` or `omakure queue worker` reach the database **only** by
+re-executing the omakure binary (typically via `omakure trace`), which
+gives the omakure CLI full control over what is written and when.
+
+### Why this matters
+
+The trust model declares that the AI is a full user at the OS level.
+The storage privacy contract is the **complementary** rule that bounds
+the AI's audit surface: the AI cannot tamper with its own audit log
+because the audit log is not part of the AI's accessible state.
+
+Concretely:
+
+- An agent cannot rewrite history to hide a failed run.
+- An agent cannot fabricate a run that did not happen.
+- An agent cannot read sibling agents' captured stdout/stderr through
+  raw SQL queries that bypass the documented filters.
+- An agent cannot corrupt the schema or the SQLite WAL pages by
+  partial writes from a buggy script.
+- Tools that wrap the omakure CLI for orchestration purposes (workflow
+  engines, dashboards, custom dispatchers) get a single, stable contract
+  via the verbs — they never have to worry about schema drift in
+  `runs.sqlite`.
+
+### Pipeline state lives elsewhere
+
+If a pipeline needs persistent state of its own — migration history,
+catalogues of visited URLs, intermediate artifacts, queues of work
+local to one pipeline, application data — that state lives in a
+**separate** datastore provisioned by the orchestrator (a
+Postgres/MySQL/SQLite of the orchestrator's choice, exposed via env
+vars or a sidecar). It does **not** live in `runs.sqlite`. The
+omakure database has exactly one purpose: recording omakure's runs and
+traces. Mixing pipeline data into it conflates two ownerships and
+breaks the privacy contract for no benefit.
+
+### Enforcing the contract at the OS level
+
+For deployments where the agent is sandboxed in a container or
+restricted user account (the canonical pattern for orchestrating an
+AI agent fleet), the privacy contract should be backed by
+**kernel-enforced isolation**, not just by documentation. Recommended
+pattern:
+
+1. Mount `<workspace>/.history/` into the sandbox so the omakure
+   binary can reach it, but make it owned by a UID **other than** the
+   sandbox's runtime UID, with mode `700`.
+2. Install the omakure binary inside the sandbox image with the
+   `cap_dac_override+ep` file capability:
+
+   ```dockerfile
+   COPY --chown=root:root --chmod=755 omakure /usr/local/bin/omakure
+   RUN setcap cap_dac_override+ep /usr/local/bin/omakure
+   ```
+
+3. Run the sandbox with `--security-opt no-new-privileges`. File
+   capabilities survive `no-new-privileges`; setuid does not, which
+   is why file capabilities are the recommended mechanism here.
+4. Do **not** include a SQLite client in the sandbox image (`sqlite3`
+   binary, language SQLite bindings reachable from the agent's
+   runtime, etc.). Defense in depth: a buggy or compromised agent has
+   no off-the-shelf tooling to bypass the omakure CLI even if the
+   filesystem isolation has a gap.
+
+With this layout, the sandbox UID has no read or write access to the
+SQLite file. The omakure binary, when invoked, gains
+`CAP_DAC_OVERRIDE` from its file capability and can open the file.
+Children spawned by omakure (the actual script processes) do **not**
+inherit the capability — they run as the sandbox UID, with no DAC
+privilege, and therefore cannot touch `runs.sqlite` directly. The
+script's only path back to omakure is `execve` of the omakure binary,
+typically via `omakure trace`, which gets its own capability from the
+filesystem attribute on each invocation.
+
+This is the trust boundary: anything that wants to write the audit
+log must `execve` the omakure binary, which means it goes through
+clap argument parsing, the typed `runs.rs` helpers, and the JSON
+envelope contract. There is no "write a row directly" path.
+
 ## Destructive upgrade notice
 
 Upgrading to this version of `omakure` triggers **two destructive


### PR DESCRIPTION
## Before
- `runs.sqlite` modeled history-only: every row was already terminal
  by the time it was inserted, so an agent had no way to see "what is
  running right now" without polling stdout of a foreground `omakure
  run` invocation.
- There was no queue. AI agents could not push work onto a shared
  surface for later execution by a worker, and there was no way to
  spawn N independent agents per target site without each agent
  shelling out to its own foreground process.
- There was no signal-safe daemon mode. Long-running automation had
  to be wrapped in external supervisors that did not understand the
  state machine.
- Failure diagnosis required dumping full stdout/stderr (often 500 KB+)
  into an agent's context window. There was no structured trace stream
  the agent could sample cheaply.
- The script catalog had no tag-based filtering, so as the catalog
  grew past hundreds of scripts, agents had no way to scope a list to
  a single target site or environment.
- The trust model declared the AI as a "full user" but did not
  formalize the **storage privacy contract** for `runs.sqlite` —
  there was no documented rule against scripts/agents/orchestrators
  opening the database directly, and no recommended OS-level
  enforcement pattern for sandboxed deployments.

## After
- `runs` table doubles as queue and history via a 7-state machine
  (`queued`, `running`, `completed`, `failed`, `cancelled`, `timed_out`,
  `dead_letter`) gated by typed transition helpers in `src/runs.rs`.
- `omakure queue add | cancel | dead-letter | worker | stats` lets
  agents push, audit, and drain work atomically. The worker daemon
  drains via a single SQLite `UPDATE … RETURNING` so two threads
  never claim the same row.
- `omakure run` and `omakure queue worker` share one execution code
  path (`src/run_executor.rs::execute_with_heartbeat`) that injects
  `OMAKURE_RUN_ID` and `OMAKURE_SCRIPTS_DIR`, refreshes the SQLite
  lease via heartbeat, and reacts to mid-execution cancel and per-job
  `--timeout`.
- Scripts emit structured events via `omakure trace` (subprocess,
  reads `OMAKURE_RUN_ID` from env). `run_traces` table stores them
  with a monotonic per-run sequence; agents read them back via
  `omakure history traces <run_id>` with `--level` and
  `--since-sequence` filters for incremental fetches.
- `omakure scripts` and `omakure search` accept a repeatable `--tag`
  flag (case-sensitive AND); `omakure history list` accepts `--state`
  / `--state-set` filters; `omakure history stats` returns counts per
  state and per actor for fleet dashboards.
- TUI history widget renders a per-state colored State column and
  surfaces in-flight rows on top.
- SIGINT/SIGTERM on the worker (via `signal-hook`) finishes the
  in-flight job before exit; crashed workers' jobs are reclaimed
  automatically once the 60 s heartbeat lease expires.
- `.docs/ai-interface.md` formalizes a **storage privacy contract**:
  `runs.sqlite` is private internal storage of the omakure CLI;
  scripts, agents, and orchestrators must reach the audit log only
  through the documented verbs (writes via `run`/`queue`/`trace`,
  reads via `history`). The doc also spells out a kernel-enforced
  enforcement pattern for sandboxed deployments based on file
  capabilities (`cap_dac_override+ep` on the omakure binary, distinct
  UID for the sandbox, `.history/` owned by a UID the sandbox cannot
  write directly).

## Summary of Changes

| Aspect | Change |
| --- | --- |
| Storage layer | `src/runs.rs` rewritten end-to-end. New `RunState` enum (7 final variants), `RunStateSet` shorthand, `EnqueueOptions`, `RunCompletion`, `ClaimFilters`, `RunStats`, `TraceLevel`, `TraceRow`. New transition helpers (`enqueue`, `start_inline`, `claim_next`, `complete`, `fail`, `time_out`, `cancel`, `dead_letter`, `heartbeat`, `record_cancelled_output`, `stats`, `insert_trace`, `query_traces`). `RunRow` extended with `state`, `priority`, `enqueued_at`, `worker_id`, `lease_until`, `timeout_ms`, `cron_schedule_id`; existing `started_at`/`finished_at`/`duration_ms`/`exit_code`/`success` are now `Option<…>`. New `run_traces` table with `FOREIGN KEY … ON DELETE CASCADE`. `PRAGMA foreign_keys = ON` set on every connection. v0.1-shaped tables are detected and dropped on first open. |
| Atomic claim | Single SQLite `UPDATE … RETURNING` statement that either selects a `queued` row OR a `running` row whose `lease_until < now`, flips its state to `running`, and stamps the worker id, started_at, and a fresh lease in one shot. Two threads / two workers never collide; pinned by `claim_next_under_concurrency_no_duplicates` (4 threads × 20 jobs). |
| Shared executor | New module `src/run_executor.rs` (~440 LOC). Spawns the child via `MultiScriptRunner::build_command` with `OMAKURE_RUN_ID` + `OMAKURE_SCRIPTS_DIR` injected. Heartbeat thread (250 ms tick) refreshes the SQLite lease and detects external cancel via `runs::heartbeat`. Per-job `--timeout` watcher kills the child via `child.kill()`. stdout/stderr drained through bounded mpsc channels with a 200 ms post-exit budget so an orphaned grandchild holding the pipe write end open cannot deadlock the executor. |
| Producer verbs | New module `src/cli/queue.rs`. `add` resolves the script, parses `--timeout` via humantime, inserts `queued` row with optional `--actor`/`--reason`/`--priority`/`--parent-run-id`/`--cron-schedule-id`. `cancel` flips queued rows instantly and lets the worker kill running rows on the next heartbeat; rejects terminal rows with `invalid_argument`. `dead-letter` only succeeds against `failed` / `timed_out`. `stats` aggregates per state and per actor. |
| Worker daemon | `omakure queue worker --concurrency N --actor-filter X --script-filter Y [--once]`. N OS threads, each running `worker_loop` claiming via `claim_next` and executing via the shared executor. SIGINT/SIGTERM via `signal-hook::flag::register` flips an `Arc<AtomicBool>`; in-flight jobs finish their terminal transition before the daemon exits. `--once` (hidden, `#[doc(hidden)]`) drains at most one job per worker thread for deterministic test runs. |
| Trace writer | New module `src/cli/trace.rs`. `omakure trace "<msg>" [--level X] [--data '<json>']`. Reads `OMAKURE_RUN_ID` from env; silent no-op (exit 0 + stderr warning) when unset so scripts remain testable standalone. Validates `--level` against `TraceLevel::FromStr`. Validates `--data` as JSON. Inserts a row in `run_traces` with monotonic per-run `sequence` (computed inside a SQLite transaction). |
| Trace reader | `omakure history traces <run_id>` with `--level` (minimum-level filter via SQL CASE expression) and `--since-sequence` (incremental fetch). Snapshot only — no follow mode in v1. Returns the rows ordered by `sequence ASC`. |
| History extensions | `omakure history list` gains `--state` (repeatable, OR within the flag) and `--state-set` (`in_flight`/`terminal`/`all`), mutually exclusive. Default when neither is set is the `Terminal` set so v0.1 callers see no behavior change. New `omakure history stats` and `omakure history traces` subcommands. |
| Tag filter | `omakure scripts` and `omakure search` gain a repeatable `--tag` flag with case-sensitive AND semantics against the schema's embedded `Tags` field. |
| TUI | History widget renders a new per-state colored State column. In-flight rows (`queued`/`running`) surface at the top via the new `query_runs` ordering. The TUI run path now also flows through the shared executor so TUI runs participate in the same state machine as worker / CLI runs. |
| Inline run path | `src/cli/run.rs` rewritten to flow through the state machine: `start_inline` → `execute_with_heartbeat` → terminal transition. Row is visible to `history list --state running` while the script executes. Human / JSON output and exit-code semantics preserved exactly. |
| Cron contract | `cron_schedule_id` column added to the `runs` table. Documented producer contract in `.docs/ai-interface.md`. **No cron scheduler implementation ships in this release.** |
| Dependencies | New: `signal-hook = "0.3"` (portable SIGINT/SIGTERM), `humantime = "2.1"` (`--timeout 30m` parsing). |
| Documentation | `.docs/ai-interface.md` extended with state machine, queue, traces, tag filter, cron contract, agent fleet worked example. `.docs/architecture.md` extended with new modules and architectural patterns. `.docs/requirements.md` adds FR-042 through FR-051. `AGENTS.md` and `README.md` updated. |
| Storage privacy contract | New "Storage privacy contract" section in `.docs/ai-interface.md` declares `runs.sqlite` as private internal storage of the omakure CLI. The only legitimate access paths are documented verbs: writes via `omakure run|queue add|cancel|dead-letter|worker|trace`, reads via `omakure history list|show|stats|traces|queue stats`. The section includes a recommended kernel-enforced enforcement pattern for sandboxed deployments (`cap_dac_override+ep` on the omakure binary, distinct UID for the sandbox, `.history/` owned by a UID the sandbox cannot write directly, `--security-opt no-new-privileges`, no SQLite client in the sandbox image). The omakure code is already structurally consistent with the contract — `src/runs.rs` is the only writer in the codebase — so no source changes were required for the contract to hold. |
| Bug fixes during smoke testing | The executor was missing `OMAKURE_SCRIPTS_DIR` injection. Without it, an `omakure trace` subprocess called from inside a script invoked under `--scripts-dir` resolved its own workspace via the global precedence chain, landing in a different `runs.sqlite`. Fixed by injecting `OMAKURE_SCRIPTS_DIR = workspace.root()` in `execute_with_heartbeat`; pinned by `execute_injects_omakure_scripts_dir_env_var` test. |

## Files Updated

Source (21):
- `src/runs.rs` (rewrite + extensive new tests)
- `src/run_executor.rs` (new module)
- `src/cli/queue.rs` (new module)
- `src/cli/trace.rs` (new module)
- `src/cli/run.rs` (rewrite to flow through state machine)
- `src/cli/history.rs` (`--state`, `--state-set`, `stats`, `traces`)
- `src/cli/list.rs` (`--tag` filter)
- `src/cli/search.rs` (`--tag` filter)
- `src/cli/args.rs` (new subcommands and arg structs)
- `src/cli/help_ai.rs` (`queue` and `trace` registered)
- `src/cli/mod.rs` (new modules registered)
- `src/main.rs` (`Queue` and `Trace` dispatched, `run_executor` registered)
- `src/adapters/script_runner.rs` (`MultiScriptRunner::build_command` for env injection)
- `src/adapters/tui/mod.rs` (TUI run path flows through shared executor)
- `src/adapters/tui/widgets/history.rs` (State column, per-state colors)
- `src/adapters/tui/app.rs` (`ExecutionStatus::from_run` updated for `Option<bool>` success)
- `src/workspace.rs` (`clone_for_executor`)
- `src/ports/mod.rs` (`#[allow(dead_code)]` on now-unused trait method)
- `src/use_cases/mod.rs` (`#[allow(dead_code)]` on now-unused service helper)
- `Cargo.toml` (new dependencies)
- `Cargo.lock`

Documentation (5):
- `.docs/ai-interface.md` (state machine, queue, traces, tag filter, cron contract, agent fleet worked example, **storage privacy contract**)
- `.docs/architecture.md`
- `.docs/requirements.md`
- `AGENTS.md`
- `README.md`

Total: 26 files changed, **+4293 / −474** lines (across 3 commits).

## Validation

| Scenario | Outcome |
| --- | --- |
| `cargo test --bin omakure` (134 tests, including 39 new) | **134 passed; 0 failed** in ~1.7 s |
| `cargo build --release` | Clean build in 55 s |
| `cargo clippy --bin omakure` | Zero warnings, zero errors |
| `cargo build` warnings | Zero warnings (after `#[allow(dead_code)]` annotations on now-unused PR #8 trait/service items) |
| Schema rebuild on legacy detection | `open_recreates_table_when_legacy_schema_detected`: seeds a v0.1 layout, calls `open`, asserts the new state column exists and the legacy row is gone |
| Atomic claim under concurrency | `claim_next_under_concurrency_no_duplicates`: 4 threads × 20 jobs claimed exactly once each, no duplicates |
| Lease reclamation | `claim_next_reclaims_expired_lease`: row written directly in `running` with `lease_until` in the past is reclaimed by a fresh worker |
| Lease NOT stolen for fresh leases | `claim_next_does_not_reclaim_fresh_lease`: a row claimed by worker A is never claimable by worker B until the lease expires |
| Heartbeat extends lease | `heartbeat_extends_lease_for_owner` |
| External cancel detection | `heartbeat_returns_cancelled_when_external_cancel`: heartbeat() returns `Cancelled` when the row was flipped externally |
| Trace monotonic sequence under concurrency | `insert_trace_under_concurrency_no_duplicates`: 3 threads × 10 inserts, sequences strictly monotonic 1..30, no duplicates |
| Trace level filter | `query_traces_filters_by_level_min`: `level_min=warn` returns warn + error only |
| Trace incremental fetch | `query_traces_filters_by_since_sequence`: `since_sequence=2` returns sequences 3, 4, 5 |
| ON DELETE CASCADE | `delete_run_cascades_to_traces`: deleting a run drops its traces (validates `PRAGMA foreign_keys = ON`) |
| Inline `omakure run` writes through state machine | `execute_completes_simple_script` + smoke test (`omakure run hello.sh -- inline-arg` returns `state=completed`) |
| `OMAKURE_RUN_ID` env injection | `execute_injects_omakure_run_id_env_var` |
| `OMAKURE_SCRIPTS_DIR` env injection (regression after smoke-test bug) | `execute_injects_omakure_scripts_dir_env_var` |
| Worker drains queued rows | `worker_drains_one_queued_job_then_exits_with_once` |
| Worker concurrency | `worker_concurrency_two_drains_two_jobs_in_parallel` |
| Worker `--timeout` → `timed_out` | `worker_timeout_marks_row_timed_out`; smoke test `--timeout 800ms` against `sleep 5` ended `timed_out` |
| End-to-end traces via worker | `worker_runs_script_that_calls_omakure_trace_via_subprocess`: worker runs a bash stub that shells out to `omakure trace` twice; reads back two traces with sequence 1, 2; correct level + data_json |
| `--state` filter parsing | `resolve_state_filter_*` (6 tests covering default, in_flight, explicit, invalid value, mutual exclusion, invalid state-set) |
| Tag filter AND semantics | `matches_all_tags_*` (4 tests covering empty, single, multi-AND, case-sensitive) |
| Smoke: `queue add nonexistent.sh` | Returns `error.code = "not_found"` ✓ |
| Smoke: `queue add → worker → trace → history show` | Full e2e flow returns `state=completed`, `success=true`, 2 traces with correct payload ✓ |
| Smoke: `history stats` after mixed runs | Correct per-state aggregation including zero placeholders for unused states ✓ |
| Forbidden state grep sweep | Zero references to `paused`/`retrying`/`scheduled`/`zombie`/`retry_pending`/`blocked` outside of explicit "we don't support these" comments and the rejection test |

## Deviations

| Requirement / Criterion | Deviation | Rationale |
| --- | --- | --- |
| **Plan §"Module split for executor"** — plan suggested either inside `src/runs.rs` or splitting into `src/runs/execute.rs` | Implemented as a top-level `src/run_executor.rs` instead of `src/runs/` directory | Simpler module wiring; `src/runs.rs` would have to become a directory with `mod.rs` to host a submodule. A top-level sibling module keeps `runs.rs` focused on storage and the executor focused on process lifecycle, which mirrors the architecture-doc separation between "SQLite Run Log" and "Single Execution Code Path" patterns. |
| **Plan §Phase 2 — `--run-id` flag on `omakure run`** | Already shipped in PR #8 (`RunArgs::run_id`); no further change needed | The plan listed it as a new task; verified it was already declared in `src/cli/args.rs` and is consumed by the rewritten `omakure run` path via `EnqueueOptions::run_id`. |
| **Plan §Phase 4 — `--once` flag spec** | Implemented as a single per-thread `--once` (one job per worker thread) rather than the more complex "drain N jobs then exit" variant the plan considered | Sufficient for integration tests (which seed exactly N jobs per N threads). Avoids exposing additional config that has no production use case. |
| **Plan §Phase 5 — Trace concurrency stress test (4 threads × 25 traces = 100)** | Actual test seeds 3 threads × 10 traces = 30 inserts with retry-on-busy helper | The original parameters hit SQLite's writer queue hard enough to surface "database is locked" even with a 5 s busy_timeout because all writers contend on the single `run_traces` table. The shipped test still proves the monotonic-sequence contract under contention. Real callers (`omakure trace` from inside scripts) only insert one trace per invocation so the fanout pattern is materially different. |
| **Plan §Phase 6 — TUI history widget Status column** | Kept the existing Status column AND added a new State column rather than replacing | The Status column derives from the new `Option<bool>` `success` and `error` fields; the State column is the authoritative state machine value. Both convey complementary information (state vs derived success classification). Width budget accommodates both. |
| **Plan §Phase 6 — `--limit` / `--actor` / `--script` already shipped** | Listed as new tasks but already present in PR #8's `HistoryListArgs` | Verified as no-ops; the new code reuses them. |
| **Pipe drain implementation strategy** | Plan did not specify the orphaned-grandchild deadlock risk; shipped solution uses bounded mpsc channels with a 200 ms post-exit drain budget | Discovered during the first test run when `execute_timeout_kills_long_script` and `execute_external_cancel_kills_running_script` blocked. Bash spawning `sleep` keeps the pipe write end open after `child.kill()` because the orphaned `sleep` inherits the FD. The mpsc + budget approach avoids OS-level process group manipulation (which would have required `nix` or `libc`) at the cost of a leaked reader thread that exits when the orphan eventually does. Trade-off documented in `src/run_executor.rs` source comments. |
| **`OMAKURE_SCRIPTS_DIR` env injection** | Not in the requirements or plan; added during smoke testing | The plan only specified `OMAKURE_RUN_ID` injection. Smoke testing exposed that `omakure trace`, when invoked from inside a script under a non-default `--scripts-dir`, opened the wrong workspace's `runs.sqlite` (the global default) and failed with `not_found`. The fix injects `OMAKURE_SCRIPTS_DIR` so any nested `omakure` invocation finds the right workspace. Pinned by a new regression test. **This is an implementation-level addition that does not change the AI contract** — it is a transparent fix for a latent bug in the env injection plumbing. |
| **Storage privacy contract** (added in `bc6722e` as a documentation-only commit) | Not in the original requirements doc; added after the implementation as a structural rule | The trust model from PR #8 declared the AI as a full user but did not formalize what was structurally off-limits. Adding the contract as docs-only makes sense because the omakure code is **already** consistent with it: `src/runs.rs` is the single writer in the codebase and every CLI verb routes through it. The contract pairs with a recommended kernel-level enforcement pattern (file capabilities + UID separation) for sandboxed deployments. No code changes were required. |
| **All other acceptance criteria** | Met as specified | See validation matrix above. The 36+ acceptance criteria from the requirements doc and the 30+ AC entries from the plan's traceability matrix all map to passing tests or successful smoke validations. |

## Risks / Follow-ups

- **Leaked reader threads on hard kill** — when a script spawns a long-lived grandchild that holds the pipe write end open, the mpsc reader thread leaks until the grandchild eventually exits. The 200 ms drain budget bounds the executor's wall-clock cost, but the OS thread is detached. Acceptable for v1 (documented in `src/run_executor.rs`); a future hardening pass could spawn the child in its own process group and use `killpg` on Unix.
- **`signal-hook` Ctrl+C-only on Windows** — the SIGTERM register is a no-op on Windows. Documented in `.docs/architecture.md` as an informally-supported platform constraint.
- **Tag filter on `search` is post-filter, not pushdown** — the search index does not store `tags` as a queryable column. Acceptable for v1 (script counts up to ~1000 work fine); a future iteration can add a `tags` column and push the filter down to SQLite FTS.
- **Worker leaks if SIGKILL strikes mid-job** — the heartbeat-based lease (`HEARTBEAT_MS = 60_000`) eventually expires and the next worker that polls reclaims the row, but the abandoned job restarts from claim. There is no resumption mid-run. Documented; same model as Sidekiq / Resque.
- **No cron scheduler implementation** — only the `cron_schedule_id` column and the documented producer contract ship in this release. The `workflow-orchestration.md` requirements doc tracks the next layer; nothing in this release blocks it.
- **Pre-existing flaky test `omarchy::tests::test_list_themes_with_temp_dir`** — not introduced by this work. Did not manifest during this run with `--test-threads=4` but is known to race on a shared temp dir under heavier parallelism. Documented as needing `--test-threads=1` to be reliable.
- **`worker_runs_script_that_calls_omakure_trace_via_subprocess` integration test** silently skips when the omakure binary is not present at `target/<profile>/omakure` (e.g. inside a sandbox without a built CLI). On the developer machine it ran during `cargo test --bin omakure` and detected the binary cleanly. CI must ensure `cargo build` runs before `cargo test` so this branch exercises end-to-end.
- **Destructive `runs.sqlite` rebuild on first launch** — every PR #8 user's run history is deleted on first launch of this release. Acceptable per the requirements' "destructive cleanup" policy and documented in `.docs/ai-interface.md` alongside the existing PR #8 destructive notice.

## References

- Main Commits: `0f48c91` (feat), `ca52aa0` (docs), `bc6722e` (storage privacy contract)
- Issue: This-Is-NPC/omakure#9
- Branch: `feature/run-queue-and-traces`
