### PR TITLE
chore: bump version to 0.1.8 and add release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omakure"
-version = "0.1.7"
+version = "0.1.8"
 repository = "https://github.com/This-Is-NPC/omakure"
 license = "AGPL-3.0-only"
 edition = "2021"

--- a/release-notes/v0.1.8.md
+++ b/release-notes/v0.1.8.md
@@ -1,0 +1,36 @@
+# v0.1.8
+
+## Highlights
+- Full AI agent CLI surface — every relevant verb now supports `--json` with a stable envelope.
+- Run history migrated from loose JSON files to a queryable SQLite store with audit fields.
+- Run queue with worker daemon, 7-state machine, and structured execution traces.
+- TUI can now open any directory as a session scripts root via positional path argument.
+
+## Added
+- `--json` global flag emitting `{ ok, data, error, schema_version }` envelope on all AI verbs.
+- `omakure describe <script>` — returns full parsed script schema.
+- `omakure search <query>` — exposes the SQLite script index from the CLI.
+- `omakure history list|show|tail` — query run history with `--script`, `--actor`, `--since`, `--until`, `--success`, `--failure`, `--limit`, `--state`, `--state-set` filters.
+- `omakure help-ai` — JSON capability payload auto-generated from CLI definition.
+- `omakure queue add` / `omakure queue worker` — run queue with atomic drain, heartbeat lease, per-job `--timeout`, and SIGINT/SIGTERM graceful shutdown.
+- `omakure trace` — structured trace events per run; `omakure history traces` with `--level` and `--since-sequence` filters.
+- `--actor`, `--reason`, `--run-id`, `--parent-run-id`, `--no-prompt` flags on `omakure run`.
+- `--schema-json`, `--body-stdin`, `--force` flags on `omakure init`.
+- `--tag` repeatable filter on `omakure scripts` and `omakure search`.
+- Positional `PATH` argument on bare `omakure` to browse any directory as session scripts root.
+- Storage privacy contract for `runs.sqlite` in AI interface documentation.
+
+## Changed
+- Run history backend replaced: `src/history.rs` (JSON files) removed in favor of `src/runs.rs` (SQLite WAL).
+- TUI history widget rewritten on `RunRow` — now shows colored State column, Actor column, and surfaces in-flight rows on top.
+- `RunRow` JSON fields `started_at`, `finished_at`, `duration_ms`, `exit_code`, and `success` are now nullable to support queued/running states.
+
+## Breaking
+- `runs.sqlite` tables missing the `state` column are dropped and recreated on first launch — legacy rows are lost.
+- `src/history.rs` and the `HistoryEntry` JSON-file format are removed with no compatibility shim. Back up `.history/` before upgrading to preserve old data.
+- On first launch, `runs::open` deletes every top-level `*.json` file in `<workspace>/.history/`.
+
+## Chores
+- `CONTRIBUTING.md` updated: `test` is the default base branch; GitHub Projects workflow with `gh` CLI documented.
+- `AGENTS.md`, `README.md`, `.docs/architecture.md`, `.docs/requirements.md` refreshed to match new module layout.
+- New documentation: `.docs/ai-interface.md`, `.docs/environments.md`, `.docs/scripts-path.md`, `.docs/usage.md`.


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` version from 0.1.7 to 0.1.8
- Add `release-notes/v0.1.8.md`