### PR TITLE
fix(tui): resolve clippy debt and saturate scroll overflows

### DIFF
--- a/.workflow/notes/lint-audit-triage.md
+++ b/.workflow/notes/lint-audit-triage.md
@@ -1,0 +1,147 @@
+# Lint & Bug Audit — Triage Table
+
+Companion artifact for `.workflow/plans/lint-and-bug-audit.md`. Each row of
+`cargo clippy --all-targets -- -D warnings` (baseline) and
+`cargo clippy --all-targets -- -W clippy::pedantic` (audit) is classified as:
+
+- **bug** — wrong runtime behavior today; fixed in this PR.
+- **latent-risk** — narrow input range or platform-dependent overflow that is
+  not reachable today but is defensively fixed.
+- **cosmetic** — style or precision-loss warning with no behavioral impact;
+  deliberately not addressed. Rationale recorded inline.
+
+## Baseline warnings (`cargo clippy --all-targets -- -D warnings`)
+
+All 6 rows were pre-existing and blocked the strict gate. Each is resolved by
+structural change (no `#[allow(...)]`).
+
+| File:line (pre-fix) | Lint | Label | Fix |
+|---|---|---|---|
+| `src/adapters/tui/events.rs:210` | `clippy::items-after-test-module` | cosmetic-blocking | `fn handle_envs_key` moved above `#[cfg(test)] mod tests`. |
+| `src/adapters/tui/theme.rs:353` | `clippy::items-after-test-module` | cosmetic-blocking | `fn selection_symbol_str` moved above `#[cfg(test)] mod tests`. |
+| `src/adapters/tui/ui.rs:236` | `clippy::items-after-test-module` | cosmetic-blocking | `fn color_to_tuple` moved above `#[cfg(test)] mod tests`. |
+| `src/cli/describe.rs:169` | `clippy::items-after-test-module` | cosmetic-blocking | `pub fn sample_envelope` moved above `#[cfg(test)] mod tests`; doc-comment preserved. |
+| `src/cli/history.rs:589` | `clippy::field-reassign-with-default` | cosmetic-blocking | Replaced `RunStats::default()` + field assignments with struct-literal init. |
+| `src/runs.rs:1909` | `clippy::while-let-loop` | cosmetic-blocking | `loop { match … { Some(x) => …, None => break } }` → `while let Some(x) = …`. |
+
+"cosmetic-blocking" = the lint itself is cosmetic/structural but is pinned at
+deny-warnings level, so it blocks the gate; the fix does not change runtime
+behavior.
+
+## Pedantic audit — bug / latent-risk rows
+
+| File:line (pre-fix) | Lint / pattern | Label | Fix |
+|---|---|---|---|
+| `src/adapters/tui/app.rs:245-253` (`scroll_env_preview`) | `u16 as i16` truncation → `u16::MAX as i16 == -1`, so `next > u16::MAX as i16` guard always fires for any non-negative sum | **bug** | Rewritten using `i32` arithmetic + `saturating_add` + `clamp(0, u16::MAX)`. 3 regression tests added (in-range advance, saturate at `u16::MAX`, saturate at 0). |
+| `src/adapters/tui/app.rs:569-576` (`scroll_run_output`) | `(-delta) as u16` when `delta == i16::MIN` invokes UB-adjacent unary-negation overflow; `(delta as u16)` when `delta > 0` is safe only because `delta` bit-pattern fits in u16 | **latent-risk** | Same `i32` saturating-clamp pattern as `scroll_env_preview`. 2 regression tests added: `i16::MIN` no-panic → saturates to 0; `i16::MAX` from `u16::MAX-5` saturates to `u16::MAX`. |
+
+## Pedantic audit — cosmetic rows (deliberately not addressed)
+
+Rationale is listed once per family; locations are enumerated.
+
+### `as isize` / `as usize` on `Vec::len()` / selection indices
+
+Sites: `src/adapters/tui/app.rs:213,214,220,260,261,267,310,311,317,376,377,383,449,450,457`.
+
+`Vec::len()` is guaranteed by Rust's allocation invariant to be ≤ `isize::MAX`
+on all supported platforms — the allocator refuses to return a region larger
+than that. Selection indices are always clamped to `[0, len-1]` before being
+cast back to `usize`. Therefore every `usize ↔ isize` round-trip here is
+lossless in practice. The warnings are stylistic preferences for explicit
+`try_from`/saturating conversions.
+
+**Decision:** cosmetic; no fix. Any future refactor that introduces
+`u32`-sized-collection semantics (e.g. WASM target or similar) would have to
+revisit.
+
+### `usize as u16` in TUI layout code (row/column heights)
+
+Sites: `src/adapters/tui/ui.rs:44`.
+
+`info_lines` is built by `environment::status_info` which returns a
+deterministic, short list (≤ ~10 lines). `u16::MAX = 65535` is two orders of
+magnitude above any realistic layout height.
+
+**Decision:** cosmetic; no fix.
+
+### `usize/u64/u128 as f64` in gauge / percentile / average math
+
+Sites: `src/adapters/tui/ui.rs:214,227`, `src/adapters/tui/widgets/dashboards.rs:70,76,77,78,79,275,380,383,752`.
+
+`f64`'s 52-bit mantissa is exact for integers up to 2^52 ≈ 4.5×10^15. Gauge
+values (run counts, durations in ms) never approach that bound. Color-lerp
+precision (0–255) is trivially within `f32` range.
+
+**Decision:** cosmetic; no fix.
+
+### `f64 as u8/u16/u32/u64` in gauge rendering
+
+Sites: `src/adapters/tui/ui.rs:227`, `src/adapters/tui/widgets/dashboards.rs:71,72,79,275,283,380,383,391`.
+
+All sites compute a ratio ∈ [0,1] or a small integer bucket before casting
+back to an integer. The upstream math is bounded so truncation is intentional
+(rounding to the nearest renderable integer).
+
+**Decision:** cosmetic; no fix.
+
+### `i64 as u64` / `u128 as u64` in `dashboards.rs`
+
+Sites: `src/adapters/tui/widgets/dashboards.rs:156` (`d as u64` guarded by
+`d >= 0`), `:172` (`(sum_u128 / len_u128) as u64` — average ms).
+
+`:156` is guarded by an explicit `if d >= 0` check immediately above, so the
+cast is sign-safe. `:172` can only truncate if the *average* duration exceeds
+`u64::MAX` milliseconds (~584 million years); unreachable.
+
+**Decision:** cosmetic; no fix.
+
+### Cast family in `src/runs.rs`
+
+~40 pedantic cast warnings across `src/runs.rs` (durations, row counts, SQLite
+`i64 ↔ u64` bridge). Every call site either:
+- reads a SQLite `INTEGER` (which is stored as `i64`) back into a `u64` domain
+  type where the producer guarantees non-negative values (enqueued-at
+  timestamps, durations); or
+- computes an aggregate in `u128` and truncates to `u64` for a domain field
+  whose semantic range is well below `u64::MAX`.
+
+No site was identified where a realistic input can trigger truncation.
+
+**Decision:** cosmetic; no fix. A follow-up ticket could introduce a
+`DurationMs(u64)` newtype bridging `i64 ↔ u64` with `try_from` — out of scope
+for this audit.
+
+### Non-cast cosmetic pedantic warnings
+
+`uninlined_format_args` (238), `redundant_closure` (14), `missing-backticks-in-docs`
+(16), `match-same-arms` (8), `unnested_or_patterns` (15), etc.
+
+Per the requirements §Out of scope ("Rewriting the entire codebase to be
+`clippy::pedantic` clean. Cosmetic pedantic warnings … stay as warnings unless
+they overlap with a real bug"), these are not addressed.
+
+**Decision:** cosmetic; no fix.
+
+### `unwrap()` in non-excluded production code
+
+Reviewed via `rg '\.unwrap\(\)' src/ -g '!**/tests/**'` after excluding the
+files listed in the requirements (`cli/{trace,doctor,uninstall,omaken,update}.rs`).
+Remaining `unwrap()` calls are in test-code blocks (`#[cfg(test)] mod tests { … }`)
+or on `Mutex::lock()` / `Option` values with a statically-guaranteed `Some`
+(post-selection-clamp indexing). No site was classified as bug or latent-risk.
+
+**Decision:** cosmetic; no fix.
+
+## Summary
+
+| Label | Count | Status |
+|---|---|---|
+| bug | 1 | fixed + 3 regression tests |
+| latent-risk | 1 | fixed + 2 regression tests |
+| cosmetic (baseline 6) | 6 | fixed structurally (to clear the gate) |
+| cosmetic (pedantic, by family) | ~500+ | deliberately deferred, rationale above |
+
+Post-fix state:
+- `cargo clippy --all-targets -- -D warnings` → exit 0.
+- `cargo clippy --all-targets -- -W clippy::pedantic` → 0 `bug`/`latent-risk`
+  rows remaining; only families classified as `cosmetic` above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,5 +109,7 @@ Before starting a new workflow cycle, check if the upstream repository has newer
 
 ## Code Standards
 
-- {Language-specific conventions, linting rules, test framework, etc.}
-- {Add project-specific patterns here}
+- `mise run lint` must exit 0 before opening a PR. It runs
+  `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check`.
+- Any new `#[allow(clippy::…)]` requires a one-line comment justifying the
+  suppression (pointing at the bug, audit note, or rationale).

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ run = "cargo test"
 
 [tasks.lint]
 description = "Run clippy and check formatting"
-run = ["cargo clippy -- -D warnings", "cargo fmt --check"]
+run = ["cargo clippy --all-targets -- -D warnings", "cargo fmt --check"]
 
 [tasks.install]
 description = "Install omakure locally"

--- a/src/adapters/environments.rs
+++ b/src/adapters/environments.rs
@@ -402,9 +402,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_load_environment_config_active_points_to_missing_file(
-        envs_dir: (TempDir, PathBuf),
-    ) {
+    fn test_load_environment_config_active_points_to_missing_file(envs_dir: (TempDir, PathBuf)) {
         let (_tmp, envs) = envs_dir;
         fs::write(envs.join("active"), "ghost.conf\n").unwrap();
         let repo = FsEnvironmentRepository::new(&envs);

--- a/src/adapters/tui/app.rs
+++ b/src/adapters/tui/app.rs
@@ -243,13 +243,9 @@ impl<'a> App<'a> {
     }
 
     pub(crate) fn scroll_env_preview(&mut self, delta: i16) {
-        let mut next = self.environment.preview_scroll as i16 + delta;
-        if next < 0 {
-            next = 0;
-        }
-        if next > u16::MAX as i16 {
-            next = u16::MAX as i16;
-        }
+        let next = i32::from(self.environment.preview_scroll)
+            .saturating_add(i32::from(delta))
+            .clamp(0, i32::from(u16::MAX));
         self.environment.preview_scroll = next as u16;
     }
 
@@ -571,12 +567,10 @@ impl<'a> App<'a> {
     }
 
     pub(crate) fn scroll_run_output(&mut self, delta: i16) {
-        if delta > 0 {
-            self.run_output_scroll = self.run_output_scroll.saturating_add(delta as u16);
-        } else if delta < 0 {
-            let amount = (-delta) as u16;
-            self.run_output_scroll = self.run_output_scroll.saturating_sub(amount);
-        }
+        let next = i32::from(self.run_output_scroll)
+            .saturating_add(i32::from(delta))
+            .clamp(0, i32::from(u16::MAX));
+        self.run_output_scroll = next as u16;
     }
 
     pub(crate) fn display_path(&self, path: &Path) -> String {
@@ -1285,6 +1279,30 @@ mod tests {
     }
 
     #[test]
+    fn test_scroll_run_output_handles_i16_min_without_panic() {
+        let tmp = TempDir::new().unwrap();
+        let svc = make_service(&tmp);
+        let ws = Workspace::new(tmp.path().to_path_buf());
+        let mut app = App::test_new(&svc, ws, vec![], vec![]);
+        app.run_output_scroll = 100;
+        // i16::MIN cannot be negated in i16 (overflow), so the pre-fix
+        // `(-delta) as u16` was UB-adjacent. Post-fix: saturating clamp to 0.
+        app.scroll_run_output(i16::MIN);
+        assert_eq!(app.run_output_scroll, 0);
+    }
+
+    #[test]
+    fn test_scroll_run_output_saturates_at_u16_max() {
+        let tmp = TempDir::new().unwrap();
+        let svc = make_service(&tmp);
+        let ws = Workspace::new(tmp.path().to_path_buf());
+        let mut app = App::test_new(&svc, ws, vec![], vec![]);
+        app.run_output_scroll = u16::MAX - 5;
+        app.scroll_run_output(i16::MAX);
+        assert_eq!(app.run_output_scroll, u16::MAX);
+    }
+
+    #[test]
     fn test_reset_run_output_scroll() {
         let tmp = TempDir::new().unwrap();
         let svc = make_service(&tmp);
@@ -1345,16 +1363,36 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_env_preview_accepts_positive_delta() {
+    fn test_scroll_env_preview_advances_positive_delta_in_range() {
         let tmp = TempDir::new().unwrap();
         let svc = make_service(&tmp);
         let ws = Workspace::new(tmp.path().to_path_buf());
         let mut app = App::test_new(&svc, ws, vec![], vec![]);
-        // The function has a known i16 overflow: u16::MAX as i16 == -1,
-        // so the `next > u16::MAX as i16` guard always triggers for
-        // non-negative results. This test documents the current behavior.
+        app.environment.preview_scroll = 100;
         app.scroll_env_preview(10);
+        assert_eq!(app.environment.preview_scroll, 110);
+    }
+
+    #[test]
+    fn test_scroll_env_preview_saturates_at_u16_max() {
+        let tmp = TempDir::new().unwrap();
+        let svc = make_service(&tmp);
+        let ws = Workspace::new(tmp.path().to_path_buf());
+        let mut app = App::test_new(&svc, ws, vec![], vec![]);
+        app.environment.preview_scroll = u16::MAX - 5;
+        app.scroll_env_preview(i16::MAX);
         assert_eq!(app.environment.preview_scroll, u16::MAX);
+    }
+
+    #[test]
+    fn test_scroll_env_preview_saturates_at_zero() {
+        let tmp = TempDir::new().unwrap();
+        let svc = make_service(&tmp);
+        let ws = Workspace::new(tmp.path().to_path_buf());
+        let mut app = App::test_new(&svc, ws, vec![], vec![]);
+        app.environment.preview_scroll = 3;
+        app.scroll_env_preview(-100);
+        assert_eq!(app.environment.preview_scroll, 0);
     }
 
     #[test]
@@ -1834,8 +1872,12 @@ mod tests {
         assert_eq!(app.environment.selection, 0);
 
         app.environment.entries = vec![
-            EnvFile { name: "a.conf".into() },
-            EnvFile { name: "b.conf".into() },
+            EnvFile {
+                name: "a.conf".into(),
+            },
+            EnvFile {
+                name: "b.conf".into(),
+            },
         ];
         app.move_env_selection(1);
         assert_eq!(app.environment.selection, 1);
@@ -1854,7 +1896,9 @@ mod tests {
         std::fs::create_dir_all(&envs).unwrap();
         std::fs::write(envs.join("dev.conf"), "FOO=bar").unwrap();
         let mut app = App::test_new(&svc, ws, vec![], vec![]);
-        app.environment.entries = vec![EnvFile { name: "dev.conf".into() }];
+        app.environment.entries = vec![EnvFile {
+            name: "dev.conf".into(),
+        }];
         app.environment.selection = 0;
 
         app.activate_selected_env();
@@ -1880,7 +1924,9 @@ mod tests {
         let ws = Workspace::new(tmp.path().to_path_buf());
         std::fs::create_dir_all(ws.envs_dir()).unwrap();
         let mut app = App::test_new(&svc, ws, vec![], vec![]);
-        app.environment.entries = vec![EnvFile { name: "ghost.conf".into() }];
+        app.environment.entries = vec![EnvFile {
+            name: "ghost.conf".into(),
+        }];
         app.environment.selection = 0;
         app.activate_selected_env();
         assert!(app.environment.error.is_some());
@@ -2011,7 +2057,10 @@ mod tests {
         app.search.status = crate::search_index::SearchStatus::Indexing;
         app.refresh_search_status();
         // Replaces with the in-memory index status (Idle).
-        assert!(matches!(app.search.status, crate::search_index::SearchStatus::Idle));
+        assert!(matches!(
+            app.search.status,
+            crate::search_index::SearchStatus::Idle
+        ));
     }
 
     #[test]
@@ -2061,10 +2110,7 @@ mod tests {
     #[test]
     fn test_schema_to_preview_queue_empty_falls_back_to_cases() {
         // A queue with neither matrix nor cases falls into the empty Cases arm.
-        let schema = crate::domain::parse_schema(
-            r#"{"Name":"X","Fields":[],"Queue":{}}"#,
-        )
-        .unwrap();
+        let schema = crate::domain::parse_schema(r#"{"Name":"X","Fields":[],"Queue":{}}"#).unwrap();
         let preview = schema_to_preview(&schema);
         match preview.queue.unwrap() {
             QueuePreview::Cases { cases } => assert!(cases.is_empty()),

--- a/src/adapters/tui/events.rs
+++ b/src/adapters/tui/events.rs
@@ -206,6 +206,22 @@ fn handle_run_result_key(app: &mut App, key: KeyEvent) {
     }
 }
 
+fn handle_envs_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => app.exit_envs(),
+        KeyCode::Char('r') | KeyCode::Char('R') => app.refresh_status(),
+        KeyCode::Down | KeyCode::Char('j') => app.move_env_selection(1),
+        KeyCode::Up | KeyCode::Char('k') => app.move_env_selection(-1),
+        KeyCode::PageDown => app.scroll_env_preview(10),
+        KeyCode::PageUp => app.scroll_env_preview(-10),
+        KeyCode::Home => app.environment.preview_scroll = 0,
+        KeyCode::End => app.environment.preview_scroll = u16::MAX,
+        KeyCode::Enter => app.activate_selected_env(),
+        KeyCode::Char('d') | KeyCode::Char('D') => app.deactivate_env(),
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -735,21 +751,5 @@ mod tests {
         app.screen = Screen::FieldInput;
         // Empty form: submit_form just walks an empty path.
         handle_key_event(&mut app, key(KeyCode::Enter));
-    }
-}
-
-fn handle_envs_key(app: &mut App, key: KeyEvent) {
-    match key.code {
-        KeyCode::Char('q') | KeyCode::Esc => app.exit_envs(),
-        KeyCode::Char('r') | KeyCode::Char('R') => app.refresh_status(),
-        KeyCode::Down | KeyCode::Char('j') => app.move_env_selection(1),
-        KeyCode::Up | KeyCode::Char('k') => app.move_env_selection(-1),
-        KeyCode::PageDown => app.scroll_env_preview(10),
-        KeyCode::PageUp => app.scroll_env_preview(-10),
-        KeyCode::Home => app.environment.preview_scroll = 0,
-        KeyCode::End => app.environment.preview_scroll = u16::MAX,
-        KeyCode::Enter => app.activate_selected_env(),
-        KeyCode::Char('d') | KeyCode::Char('D') => app.deactivate_env(),
-        _ => {}
     }
 }

--- a/src/adapters/tui/theme.rs
+++ b/src/adapters/tui/theme.rs
@@ -349,6 +349,10 @@ fn parse_hex_color(value: &str) -> Result<Color, ThemeParseError> {
     Ok(Color::Rgb(red, green, blue))
 }
 
+pub(crate) fn selection_symbol_str() -> &'static str {
+    "> "
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -403,7 +407,10 @@ error = "#ffff00"
 
     #[test]
     fn parse_hex_color_accepts_full_form_without_prefix() {
-        assert_eq!(parse_hex_color("ffffff").unwrap(), Color::Rgb(255, 255, 255));
+        assert_eq!(
+            parse_hex_color("ffffff").unwrap(),
+            Color::Rgb(255, 255, 255)
+        );
     }
 
     #[test]
@@ -422,10 +429,8 @@ error = "#ffff00"
 
     #[test]
     fn theme_load_error_displays_io_and_parse() {
-        let io_err = ThemeLoadError::from(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "missing",
-        ));
+        let io_err =
+            ThemeLoadError::from(std::io::Error::new(std::io::ErrorKind::NotFound, "missing"));
         assert!(format!("{}", io_err).contains("io error"));
 
         let parse_err: toml::de::Error = toml::from_str::<i32>("not a number").unwrap_err();
@@ -560,8 +565,4 @@ error = "#ffff00"
 "##;
         assert!(load_theme_from_str(toml).is_err());
     }
-}
-
-pub(crate) fn selection_symbol_str() -> &'static str {
-    "> "
 }

--- a/src/adapters/tui/ui.rs
+++ b/src/adapters/tui/ui.rs
@@ -232,6 +232,30 @@ fn lerp_color(start: (u8, u8, u8), end: (u8, u8, u8), t: f32) -> Color {
     )
 }
 
+fn color_to_tuple(color: Color) -> (u8, u8, u8) {
+    match color {
+        Color::Rgb(r, g, b) => (r, g, b),
+        Color::Black => (0, 0, 0),
+        Color::Red => (255, 0, 0),
+        Color::Green => (0, 255, 0),
+        Color::Yellow => (255, 255, 0),
+        Color::Blue => (0, 0, 255),
+        Color::Magenta => (255, 0, 255),
+        Color::Cyan => (0, 255, 255),
+        Color::Gray => (128, 128, 128),
+        Color::DarkGray => (64, 64, 64),
+        Color::LightRed => (255, 128, 128),
+        Color::LightGreen => (128, 255, 128),
+        Color::LightYellow => (255, 255, 128),
+        Color::LightBlue => (128, 128, 255),
+        Color::LightMagenta => (255, 128, 255),
+        Color::LightCyan => (128, 255, 255),
+        Color::White => (255, 255, 255),
+        Color::Indexed(value) => (value, value, value),
+        Color::Reset => (255, 255, 255),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,29 +519,5 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| render_ui(f, &mut app, &theme)).unwrap();
-    }
-}
-
-fn color_to_tuple(color: Color) -> (u8, u8, u8) {
-    match color {
-        Color::Rgb(r, g, b) => (r, g, b),
-        Color::Black => (0, 0, 0),
-        Color::Red => (255, 0, 0),
-        Color::Green => (0, 255, 0),
-        Color::Yellow => (255, 255, 0),
-        Color::Blue => (0, 0, 255),
-        Color::Magenta => (255, 0, 255),
-        Color::Cyan => (0, 255, 255),
-        Color::Gray => (128, 128, 128),
-        Color::DarkGray => (64, 64, 64),
-        Color::LightRed => (255, 128, 128),
-        Color::LightGreen => (128, 255, 128),
-        Color::LightYellow => (255, 255, 128),
-        Color::LightBlue => (128, 128, 255),
-        Color::LightMagenta => (255, 128, 255),
-        Color::LightCyan => (128, 255, 255),
-        Color::White => (255, 255, 255),
-        Color::Indexed(value) => (value, value, value),
-        Color::Reset => (255, 255, 255),
     }
 }

--- a/src/adapters/tui/widgets/envs.rs
+++ b/src/adapters/tui/widgets/envs.rs
@@ -226,8 +226,12 @@ mod tests {
         let ws = crate::workspace::Workspace::new(root.clone());
         let mut app = App::test_new(&svc, ws, vec![], vec![]);
         app.environment.entries = vec![
-            EnvFile { name: "dev.conf".into() },
-            EnvFile { name: "prod.conf".into() },
+            EnvFile {
+                name: "dev.conf".into(),
+            },
+            EnvFile {
+                name: "prod.conf".into(),
+            },
         ];
         app.environment.config = Some(crate::ports::EnvironmentConfig {
             envs_dir: root.clone(),

--- a/src/adapters/tui/widgets/schema.rs
+++ b/src/adapters/tui/widgets/schema.rs
@@ -294,7 +294,12 @@ mod tests {
         let lines = build_lines(Some(&preview), None, &theme);
         let joined = lines
             .iter()
-            .map(|l| l.spans.iter().map(|s| s.content.to_string()).collect::<String>())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.to_string())
+                    .collect::<String>()
+            })
             .collect::<Vec<_>>()
             .join("\n");
         assert!(joined.contains("Outputs: 1"));
@@ -333,7 +338,12 @@ mod tests {
         let lines = build_lines(Some(&preview), None, &theme);
         let joined = lines
             .iter()
-            .map(|l| l.spans.iter().map(|s| s.content.to_string()).collect::<String>())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.to_string())
+                    .collect::<String>()
+            })
             .collect::<Vec<_>>()
             .join("\n");
         assert!(joined.contains("Queue: Cases (2)"));

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -165,6 +165,28 @@ fn print_human(script_path: &Path, root: &Path, schema: &Schema) {
 
 /// Render a sample envelope shape for `omakure help-ai`. Builds a fake
 /// payload so the JSON example does not depend on a real workspace.
+pub fn sample_envelope() -> serde_json::Value {
+    json::ok_envelope(json!({
+        "absolute_path": "/abs/scripts/deploy.sh",
+        "relative_path": "deploy.sh",
+        "name": "deploy",
+        "description": "Deploy the service",
+        "tags": ["ops"],
+        "fields": [
+            {
+                "name": "target",
+                "prompt": "Target environment",
+                "type": "string",
+                "order": 1,
+                "required": true,
+                "arg": "--target",
+                "default": null,
+                "choices": ["dev", "prod"]
+            }
+        ]
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -249,7 +271,9 @@ mod tests {
         );
         run(
             tmp.path().to_path_buf(),
-            DescribeArgs { script: "deploy.sh".into() },
+            DescribeArgs {
+                script: "deploy.sh".into(),
+            },
             false,
         )
         .unwrap();
@@ -265,7 +289,9 @@ mod tests {
         );
         run(
             tmp.path().to_path_buf(),
-            DescribeArgs { script: "deploy.sh".into() },
+            DescribeArgs {
+                script: "deploy.sh".into(),
+            },
             true,
         )
         .unwrap();
@@ -291,7 +317,9 @@ mod tests {
         write_schema_script(&tmp, "bare.sh", "#!/usr/bin/env bash\necho hi\n");
         let err = run(
             tmp.path().to_path_buf(),
-            DescribeArgs { script: "bare.sh".into() },
+            DescribeArgs {
+                script: "bare.sh".into(),
+            },
             false,
         )
         .unwrap_err();
@@ -306,26 +334,4 @@ mod tests {
         assert!(envelope["data"]["fields"].is_array());
         assert_eq!(envelope["schema_version"], "1");
     }
-}
-
-pub fn sample_envelope() -> serde_json::Value {
-    json::ok_envelope(json!({
-        "absolute_path": "/abs/scripts/deploy.sh",
-        "relative_path": "deploy.sh",
-        "name": "deploy",
-        "description": "Deploy the service",
-        "tags": ["ops"],
-        "fields": [
-            {
-                "name": "target",
-                "prompt": "Target environment",
-                "type": "string",
-                "order": 1,
-                "required": true,
-                "arg": "--target",
-                "default": null,
-                "choices": ["dev", "prod"]
-            }
-        ]
-    }))
 }

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -586,11 +586,14 @@ mod tests {
 
     #[test]
     fn format_stats_lines_sorts_state_and_actor_names() {
-        let mut stats = RunStats::default();
-        stats.total = 3;
-        stats.counts_by_state =
-            HashMap::from([("running".to_string(), 1), ("completed".to_string(), 2)]);
-        stats.counts_by_actor = HashMap::from([("human".to_string(), 2), ("ai".to_string(), 1)]);
+        let stats = RunStats {
+            total: 3,
+            counts_by_state: HashMap::from([
+                ("running".to_string(), 1),
+                ("completed".to_string(), 2),
+            ]),
+            counts_by_actor: HashMap::from([("human".to_string(), 2), ("ai".to_string(), 1)]),
+        };
 
         let lines = format_stats_lines(&stats);
 
@@ -728,7 +731,10 @@ mod tests {
         run(
             scripts_dir.clone(),
             HistoryArgs {
-                command: HistoryCommand::Tail(HistoryTailArgs { limit: 5, follow: false }),
+                command: HistoryCommand::Tail(HistoryTailArgs {
+                    limit: 5,
+                    follow: false,
+                }),
             },
             true,
         )
@@ -875,12 +881,7 @@ mod tests {
     fn show_human_and_json_formats_succeed() {
         let workspace = temp_workspace();
         let id = enqueue_one(&workspace);
-        show(
-            &workspace,
-            HistoryShowArgs { run_id: id.clone() },
-            false,
-        )
-        .unwrap();
+        show(&workspace, HistoryShowArgs { run_id: id.clone() }, false).unwrap();
         show(&workspace, HistoryShowArgs { run_id: id }, true).unwrap();
     }
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -169,12 +169,7 @@ mod tests {
             Some(r#"{"Name":"Deploy","Tags":["ops"],"Fields":[]}"#),
         );
         write_script(tmp.path(), "bare.sh", None);
-        run(
-            tmp.path().to_path_buf(),
-            ScriptsArgs { tag: vec![] },
-            false,
-        )
-        .unwrap();
+        run(tmp.path().to_path_buf(), ScriptsArgs { tag: vec![] }, false).unwrap();
     }
 
     #[test]
@@ -203,11 +198,6 @@ mod tests {
     #[test]
     fn run_human_format_no_scripts() {
         let tmp = tempfile::TempDir::new().unwrap();
-        run(
-            tmp.path().to_path_buf(),
-            ScriptsArgs { tag: vec![] },
-            false,
-        )
-        .unwrap();
+        run(tmp.path().to_path_buf(), ScriptsArgs { tag: vec![] }, false).unwrap();
     }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1906,11 +1906,10 @@ mod tests {
                 let conn = open_connection(&path).expect("open per-thread");
                 let mut claimed = Vec::new();
                 let worker_id = format!("worker-{}", w);
-                loop {
-                    match claim_next(&conn, &worker_id, &ClaimFilters::default()).unwrap() {
-                        Some(row) => claimed.push(row.run_id),
-                        None => break,
-                    }
+                while let Some(row) =
+                    claim_next(&conn, &worker_id, &ClaimFilters::default()).unwrap()
+                {
+                    claimed.push(row.run_id);
                 }
                 claimed
             }));
@@ -2287,10 +2286,13 @@ mod tests {
         )
         .unwrap();
 
-        let err = query_runs(&conn, &RunFilters {
-            states: vec![],
-            ..Default::default()
-        })
+        let err = query_runs(
+            &conn,
+            &RunFilters {
+                states: vec![],
+                ..Default::default()
+            },
+        )
         .unwrap_err();
         assert!(err.contains("invalid run state") || err.contains("Row query_runs failed"));
 


### PR DESCRIPTION
## Before
- `cargo clippy --all-targets -- -D warnings` failed with 6 baseline warnings (4 × `items-after-test-module`, 1 × `field-reassign-with-default`, 1 × `while-let-loop`).
- `App::scroll_env_preview` cast `u16::MAX as i16` (= -1), so any non-negative `delta` snapped `preview_scroll` to `u16::MAX` instead of advancing — bug was *documented* by a passing test, not fixed.
- `App::scroll_run_output` negated `i16` via `(-delta) as u16`, which is UB-adjacent for `i16::MIN` (same bug family, latent).
- `mise run lint` ran `cargo clippy -- -D warnings` (no `--all-targets`), so test-only lints could regress without notice; CONTRIBUTING had only a placeholder under Code Standards.
- No triage artifact existed for the dozens of `clippy::pedantic` cast warnings concentrated in `adapters/tui/app.rs`, `adapters/tui/ui.rs`, `adapters/tui/widgets/dashboards.rs`, `runs.rs`.

## After
- `cargo clippy --all-targets -- -D warnings` exits 0 with zero `#[allow(...)]` introduced.
- `scroll_env_preview` and `scroll_run_output` use `i32`-widened `saturating_add` + `clamp(0, u16::MAX)`; deltas in `[-i16::MAX, i16::MAX]` advance correctly and saturate at the boundaries.
- `mise run lint` runs `cargo clippy --all-targets -- -D warnings && cargo fmt --check`; CONTRIBUTING documents that this gate must pass before opening a PR and that any new `#[allow(...)]` requires a justifying comment.
- Full pedantic triage published at `.workflow/notes/lint-audit-triage.md` (1 bug, 1 latent-risk, 6 baseline cosmetic-blocking, ~500 cosmetic deferred with rationale).

## Summary of Changes
| Aspect | Change |
| --- | --- |
| Baseline lint debt | 6 baseline warnings resolved structurally — production items moved above `#[cfg(test)] mod tests` in `events.rs`/`theme.rs`/`ui.rs`/`describe.rs`; struct-literal init in `history.rs`; `while let Some(...)` in `runs.rs`. |
| Bug fix | `scroll_env_preview` rewritten with `i32` saturating-clamp arithmetic; buggy-behavior test deleted; 3 regression tests added (in-range, saturate-high, saturate-zero). |
| Latent-risk fix | `scroll_run_output` rewritten with the same pattern; 2 regression tests added (`i16::MIN` no-panic, saturate-high). |
| Guardrail | `[tasks.lint]` in `mise.toml` updated to `--all-targets`; CONTRIBUTING Code Standards section replaced placeholder with the lint-gate rule and `#[allow(...)]` justification rule. |
| Triage deliverable | `.workflow/notes/lint-audit-triage.md` created with full bug/latent-risk/cosmetic table. |
| Mechanical fmt | `cargo fmt` pass on 4 unrelated files (`environments.rs`, `widgets/envs.rs`, `widgets/schema.rs`, `cli/list.rs`) that had pre-existing drift, required for the new `fmt --check` gate. |

## Files Updated
- `src/adapters/tui/app.rs`
- `src/adapters/tui/events.rs`
- `src/adapters/tui/theme.rs`
- `src/adapters/tui/ui.rs`
- `src/cli/describe.rs`
- `src/cli/history.rs`
- `src/runs.rs`
- `src/adapters/environments.rs` (fmt-only)
- `src/adapters/tui/widgets/envs.rs` (fmt-only)
- `src/adapters/tui/widgets/schema.rs` (fmt-only)
- `src/cli/list.rs` (fmt-only)
- `mise.toml`
- `CONTRIBUTING.md`
- `.workflow/notes/lint-audit-triage.md`

## Deviations
| Requirement / Criterion | Deviation | Rationale |
| --- | --- | --- |
| §Acceptance Criteria — "Lint cleanup" / no `#[allow(...)]` without justifying comment | None | Zero `#[allow(...)]` introduced. |
| §Acceptance Criteria — 6 baseline `--tests` warnings resolved by structural change | None | All 6 fixed structurally at the file:line locations listed in the requirement. |
| §Acceptance Criteria — `scroll_env_preview` advances by `delta` in `[-i16::MAX, i16::MAX]`, clamped to `[0, u16::MAX]`, with the documenting test rewritten to assert correct behavior | None | Implementation uses `i32`-widened `saturating_add` + `clamp`; original buggy test deleted, replaced by 3 correct-behavior regression tests. |
| §Acceptance Criteria — pedantic cast audit; bug/latent-risk fixed with regression test, cosmetic explicitly classified | None | 1 bug (`scroll_env_preview`) and 1 latent-risk (`scroll_run_output`) fixed with regression tests; remaining cast families classified as cosmetic with per-family rationale in the triage. |
| §Acceptance Criteria — Audit deliverable (triage table in PR description or `.workflow/notes/`) | Partial deviation | Triage table written to `.workflow/notes/lint-audit-triage.md` per the requirement's "or" clause. Mirroring it into the PR description is a Phase 6 step that runs at PR-open time. |
| §Acceptance Criteria — Guardrail (`mise run lint` runs both clippy `--all-targets` and `cargo fmt --check`) and CONTRIBUTING note | None | `mise.toml` updated in place (no duplicate task); CONTRIBUTING Code Standards rewritten. |
| §Definition of Done — `cargo test` + integration binary pass | Met | 678 + 6 passing. |
| §Definition of Done — coverage ≥ 90% (no regression vs 93.34%) | Met | 93.32% (−0.03 pp), well within the threshold. |
| §Definition of Done — `mise run lint` wired and documented | Met | Verified by running `mise run lint`; both subcommands exit 0. |

## References
- Main Commits: `c7aa894`
- Issue: not tracked in GitHub Projects for this task (workflow used local `.workflow/requirements/lint-and-bug-audit.md` as source of truth).
- Branch: `feature/lint-and-bug-audit`