### PR TITLE
chore: bump version to v0.1.9 and add release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "omakure"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omakure"
-version = "0.1.8"
+version = "0.1.9"
 repository = "https://github.com/This-Is-NPC/omakure"
 license = "AGPL-3.0-only"
 edition = "2021"

--- a/release-notes/v0.1.9.md
+++ b/release-notes/v0.1.9.md
@@ -1,0 +1,47 @@
+# v0.1.9
+
+## Highlights
+- Native cron scheduler with `omakure serve`, overlap protection, dead-letter handling, and per-workspace systemd autostart.
+- TUI UX pass: unified table styling, compact activity grid, upcoming scheduled runs overlay, dynamic schema preview, tmux-style `Ctrl+/` prefix navigation.
+- Test coverage pushed from 68% to 93% across all layers.
+- 300+ SharePoint and Microsoft Teams PowerShell automation scripts.
+
+## Added
+- `omakure serve` — background cron scheduler daemon with SQLite-backed run persistence, overlap protection, dead-letter timeout, and configurable tick interval.
+- `omakure serve --autostart` — per-workspace systemd unit generation and management (enable/disable/status).
+- Activity grid widget — 6-period heatmap (LastMinute, LastHour, Day, Week, Month, Year) showing run outcomes with color-coded cells.
+- Upcoming scheduled runs overlay — cyan `▒` cells on Day/Week/Month/Year activity grids showing future cron fires; legend shows `scheduled N` entry.
+- `table_style` module — shared table/list styling helpers: header rows with ruler + `┼` intersections, `│` column separators, `padded_block`, consistent `highlight_style`/`highlight_symbol`.
+- `Ctrl+/` prefix navigation — tmux-style cross-screen navigation (`s` Search, `e` Envs, `h` History, `c` Schedules, `q` Quit); command palette shown in footer when prefix is active; handles ABNT2, legacy, and kitty terminal key variants.
+- Dynamic schema preview — grows with field count, caps at 50% of right pane height, scrollable via `PageUp`/`PageDown`.
+- Active environment badge — `env: <name>` shown in ScriptSelect footer bottom-right.
+- `doctor schemas` check — surfaces unparseable scripts during `omakure doctor`.
+- 300+ SharePoint PowerShell scripts across 17 categories (setup, sites, hubs, permissions, lists, fields, items, pages, search, flows, term store, apps, compliance, migration, monitoring, recycle bin, multi-geo).
+- Microsoft Teams automation scripts (teams, channels, apps, policies, meetings, call queues, auto-attendants).
+- New documentation: `scheduling.md`, `tui-screens-and-widgets.md`, `scripts-path.md`.
+- `hello-world.bash` sample script with embedded `Schedule` block.
+
+## Changed
+- Activity grid cells compacted to single-row sizes: Day/Year `(2,1)`, Week/Month/LastHour/LastMinute `(3,1)` — fixes visual breakage in narrow panes.
+- History table: uses `table_style` helpers with visible column separators, ruler header, responsive Script column, padded block.
+- Schedules table: migrated from per-row `REVERSED` to proper `TableState` + `highlight_style`/`highlight_symbol`; visible grid applied.
+- All lists (Scripts, Envs, Search) now use shared `block` helper for consistent bordered titles.
+- Cross-screen navigation shortcuts (`Ctrl+S`, `Alt+E`, `h`, `c`, `q`) replaced by `Ctrl+/` prefix; direct `q` bindings removed in favor of `Esc` for back.
+- Schedules loaded eagerly at startup so ScriptSelect activity grid can overlay upcoming fires immediately.
+- `Field.order` made optional with declaration-order fallback.
+- All shortcut references updated across 5 documentation files to reflect prefix navigation.
+- CLI `--help` text and `usage.md` overhauled.
+- `dev-daemon.sh` relocated to `.scripts/`.
+
+## Fixed
+- LastMinute/LastHour activity grid breaking visually in the ScriptSelect right pane (cells were too wide for the available area).
+- High-frequency crons (`*/10 * * * * *`) only marking one future day in the upcoming overlay — anchor now advances per bucket instead of per fire.
+- `Ctrl+/` not detected on ABNT2 keyboards (terminal sends `Char('7')` + CONTROL instead of `Char('/')` + CONTROL).
+- Clippy warnings across the TUI layer resolved.
+- Scroll overflows saturated to prevent panics.
+
+## Chores
+- Test coverage pushed from 68% to 93%: 290+ new tests across CLI, TUI, domain, and widget layers; snapshot tests for all render paths.
+- Added `cron`, `chrono`, `insta`, `tempfile` dependencies.
+- PowerShell toolchain added to `mise.toml`.
+- `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `.docs/architecture.md`, `.docs/requirements.md` refreshed.


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version from `0.1.8` to `0.1.9`
- Add `release-notes/v0.1.9.md` covering scheduler, TUI UX pass, test coverage, scripts, and docs