### PR TITLE
fix(ci): resolve collapsible_match lint and stabilize flaky trace test

### DIFF
--- a/src/adapters/tui/events.rs
+++ b/src/adapters/tui/events.rs
@@ -186,10 +186,8 @@ fn handle_history_list_key(app: &mut App, key: KeyEvent) {
 fn handle_history_dashboards_key(app: &mut App, key: KeyEvent) {
     let has_selection = !app.history.entries.is_empty();
     match key.code {
-        KeyCode::Esc => {
-            if app.history.dashboards_escape() {
-                app.screen = Screen::ScriptSelect;
-            }
+        KeyCode::Esc if app.history.dashboards_escape() => {
+            app.screen = Screen::ScriptSelect;
         }
         KeyCode::Char('e') | KeyCode::Char('E') | KeyCode::Enter if has_selection => {
             app.history.toggle_dashboard_expand();

--- a/src/cli/queue.rs
+++ b/src/cli/queue.rs
@@ -733,7 +733,7 @@ mod tests {
 
         let (ws, _dir) = make_workspace("e2e_trace");
         let script_body = format!(
-            "{} trace 'first' --level info\n{} trace 'second' --level warn --data '{{\"k\":1}}'",
+            "{} trace 'first' --level info\nsleep 0.2\n{} trace 'second' --level warn --data '{{\"k\":1}}'",
             bin.display(),
             bin.display()
         );


### PR DESCRIPTION
## Summary

- Collapse nested `if` inside `Esc` match arm to satisfy `clippy::collapsible_match` on Rust 1.95 (CI)
- Add 200ms sleep between two `omakure trace` subprocess calls in e2e trace test to avoid SQLite WAL race