### PR TITLE
fix: honor nested omakureignore files

### DIFF
--- a/.docs/scripts-path.md
+++ b/.docs/scripts-path.md
@@ -62,10 +62,11 @@ env.
 
 ## Exclude paths from scanning
 
-Create a `.omakureignore` file at the scripts root to keep matching files
-and directories out of Omakure's script scan. Ignored scripts do not appear
-in the TUI, `omakure scripts`, the search index, or the scheduler because
-all of those surfaces use the same recursive scanner.
+Create a `.omakureignore` file at the scripts root, or inside any child
+directory, to keep matching files and directories out of Omakure's script
+scan. Ignored scripts do not appear in the TUI, `omakure scripts`, the
+search index, or the scheduler because all of those surfaces use the same
+recursive scanner.
 
 Example:
 
@@ -80,9 +81,12 @@ scratch.py
 Supported pattern subset:
 
 - Blank lines and lines starting with `#` are ignored.
-- Patterns are evaluated relative to the scripts root.
-- A leading `/` anchors the same root-relative path (`/scratch.py` matches
-  `scratch.py`).
+- Patterns are evaluated relative to the directory containing that
+  `.omakureignore` file. When multiple files apply while Omakure descends a
+  tree, parent rules and child rules are both active.
+- A leading `/` anchors to the directory containing that `.omakureignore`
+  (`/scratch.py` in `scripts/.omakureignore` matches `scripts/scratch.py`,
+  not `other/scratch.py`).
 - A trailing `/` means directory-only and prunes the whole subtree, for
   example `helpers/` skips `helpers` and everything below it.
 - `*` matches any sequence of characters.
@@ -91,11 +95,11 @@ Supported pattern subset:
 - Patterns without `/` match any path component, for example `scratch.py`
   or `*.tmp.py` at any depth.
 
-Unsupported gitignore features are not implemented: nested `.omakureignore`
-files, negation with `!`, `**` special semantics, character classes, and
-escaped `#` comments. If `.omakureignore` cannot be read or decoded, Omakure
-prints a warning and continues scanning with only the built-in skips
-(`.history`, `.git`, and `.omaken/envs`).
+Nested `.omakureignore` files are supported. Unsupported gitignore features
+are not implemented: negation with `!`, `**` special semantics, character
+classes, and escaped `#` comments. If `.omakureignore` cannot be read or
+decoded, Omakure prints a warning and continues scanning with the remaining
+ignore rules plus the built-in skips (`.history`, `.git`, and `.omaken/envs`).
 
 ## Development note
 

--- a/.docs/scripts-path.md
+++ b/.docs/scripts-path.md
@@ -90,8 +90,8 @@ Supported pattern subset:
 - A trailing `/` means directory-only and prunes the whole subtree, for
   example `helpers/` skips `helpers` and everything below it.
 - `*` matches any sequence of characters.
-- Patterns containing `/` match the root-relative path, for example
-  `fixtures/*.sh`.
+- Patterns containing `/` match paths relative to the directory containing
+  that `.omakureignore`, for example `fixtures/*.sh`.
 - Patterns without `/` match any path component, for example `scratch.py`
   or `*.tmp.py` at any depth.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ current session. History, environments, the search index, and
 creates `.omaken/`, `.history/`, or `omakure.toml` inside the directory
 you point it at.
 
-3) Put scripts under `~/Documents/omakure-scripts` (Windows: `%USERPROFILE%\Documents\omakure-scripts`). Omakure scans this tree (including `.omaken`) for `.bash`, `.sh`, `.ps1`, and `.py` scripts. To hide helpers, fixtures, or vendored folders from the TUI, `omakure scripts`, search, and the scheduler, add a `.omakureignore` file at the scripts root.
+3) Put scripts under `~/Documents/omakure-scripts` (Windows: `%USERPROFILE%\Documents\omakure-scripts`). Omakure scans this tree (including `.omaken`) for `.bash`, `.sh`, `.ps1`, and `.py` scripts. To hide helpers, fixtures, or vendored folders from the TUI, `omakure scripts`, search, and the scheduler, add `.omakureignore` files at the scripts root or inside child folders.
 
 4) Make the script visible to Omakure by embedding a schema JSON block between `OMAKURE_SCHEMA_START` and `OMAKURE_SCHEMA_END`. The `omakure init my-script` command generates a template with the schema block.
 

--- a/src/adapters/workspace_repository.rs
+++ b/src/adapters/workspace_repository.rs
@@ -22,7 +22,7 @@ impl ScriptRepository for FsWorkspaceRepository {
     fn list_entries(&self, dir: &Path) -> io::Result<Vec<WorkspaceEntry>> {
         let mut entries_out = Vec::new();
         let entries = read_dir_or_empty(dir)?;
-        let ignore = OmakureIgnore::load(&self.root);
+        let ignore = IgnoreContext::load_for_dir(&self.root, dir);
 
         for entry in entries {
             let path = entry.path();
@@ -57,7 +57,7 @@ impl ScriptRepository for FsWorkspaceRepository {
 
     fn list_scripts_recursive(&self) -> io::Result<Vec<PathBuf>> {
         let mut scripts = Vec::new();
-        let ignore = OmakureIgnore::load(&self.root);
+        let ignore = IgnoreContext::load_for_dir(&self.root, &self.root);
         collect_scripts(&self.root, &ignore, &mut scripts)?;
         Ok(scripts)
     }
@@ -80,7 +80,7 @@ impl ScriptRepository for FsWorkspaceRepository {
 
 fn collect_scripts(
     dir: &Path,
-    ignore: &OmakureIgnore,
+    ignore: &IgnoreContext,
     scripts: &mut Vec<PathBuf>,
 ) -> io::Result<()> {
     let entries = read_dir_or_empty(dir)?;
@@ -91,7 +91,8 @@ fn collect_scripts(
             if should_skip_dir(&path) || ignore.matches(&path, true) {
                 continue;
             }
-            collect_scripts(&path, ignore, scripts)?;
+            let child_ignore = ignore.with_dir(&path);
+            collect_scripts(&path, &child_ignore, scripts)?;
         } else if path.is_file() && script_kind(&path).is_some() && !ignore.matches(&path, false) {
             scripts.push(path);
         }
@@ -100,13 +101,51 @@ fn collect_scripts(
     Ok(())
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
+struct IgnoreContext {
+    files: Vec<OmakureIgnore>,
+}
+
+impl IgnoreContext {
+    fn load_for_dir(root: &Path, dir: &Path) -> Self {
+        let mut context = Self::default();
+        let Ok(rel) = dir.strip_prefix(root) else {
+            return context.with_dir(root);
+        };
+
+        context = context.with_dir(root);
+        let mut cursor = root.to_path_buf();
+        for component in rel.components() {
+            let std::path::Component::Normal(part) = component else {
+                continue;
+            };
+            cursor.push(part);
+            context = context.with_dir(&cursor);
+        }
+        context
+    }
+
+    fn with_dir(&self, dir: &Path) -> Self {
+        let mut next = self.clone();
+        let ignore = OmakureIgnore::load(dir);
+        if !ignore.patterns.is_empty() {
+            next.files.push(ignore);
+        }
+        next
+    }
+
+    fn matches(&self, path: &Path, is_dir: bool) -> bool {
+        self.files.iter().any(|ignore| ignore.matches(path, is_dir))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
 struct OmakureIgnore {
     root: PathBuf,
     patterns: Vec<IgnorePattern>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct IgnorePattern {
     pattern: String,
     anchored: bool,
@@ -531,6 +570,141 @@ mod tests {
         assert!(!names.contains(&"infra".to_string()));
         assert!(!names.contains(&"setup.py".to_string()));
         assert!(names.contains(&"deploy.sh".to_string()));
+    }
+
+    #[test]
+    fn test_list_entries_honors_nested_omakureignore_from_parent_root() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let scripts = root.join("scripts");
+        fs::create_dir_all(scripts.join("helpers")).unwrap();
+        fs::write(scripts.join("deploy.sh"), "#!/bin/bash").unwrap();
+        fs::write(scripts.join("scratch.py"), "print('scratch')").unwrap();
+        fs::write(scripts.join("helpers/internal.sh"), "#!/bin/bash").unwrap();
+        fs::write(scripts.join(".omakureignore"), "helpers/\nscratch.py\n").unwrap();
+
+        let repo = FsWorkspaceRepository::new(root);
+        let entries = repo.list_entries(&scripts).unwrap();
+        let names: Vec<String> = entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .path
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(names.contains(&"deploy.sh".to_string()));
+        assert!(!names.contains(&"scratch.py".to_string()));
+        assert!(!names.contains(&"helpers".to_string()));
+    }
+
+    #[test]
+    fn test_recursive_scan_honors_nested_omakureignore_from_parent_root() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let scripts = root.join("scripts");
+        fs::create_dir_all(scripts.join("helpers")).unwrap();
+        fs::write(scripts.join("deploy.sh"), "#!/bin/bash").unwrap();
+        fs::write(scripts.join("scratch.py"), "print('scratch')").unwrap();
+        fs::write(scripts.join("helpers/internal.sh"), "#!/bin/bash").unwrap();
+        fs::write(scripts.join(".omakureignore"), "helpers/\nscratch.py\n").unwrap();
+
+        let repo = FsWorkspaceRepository::new(root);
+        let found: Vec<String> = repo
+            .list_scripts_recursive()
+            .unwrap()
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(found.contains(&"scripts/deploy.sh".to_string()));
+        assert!(!found.contains(&"scripts/scratch.py".to_string()));
+        assert!(!found.contains(&"scripts/helpers/internal.sh".to_string()));
+    }
+
+    #[test]
+    fn test_nested_omakureignore_combines_parent_and_child_rules() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let scripts = root.join("scripts");
+        fs::create_dir_all(&scripts).unwrap();
+        fs::write(root.join("keep.sh"), "#!/bin/bash").unwrap();
+        fs::write(scripts.join("visible.sh"), "#!/bin/bash").unwrap();
+        fs::write(scripts.join("local.py"), "print('local')").unwrap();
+        fs::write(scripts.join("global.tmp.sh"), "#!/bin/bash").unwrap();
+        fs::write(root.join(".omakureignore"), "*.tmp.sh\n").unwrap();
+        fs::write(scripts.join(".omakureignore"), "local.py\n").unwrap();
+
+        let repo = FsWorkspaceRepository::new(root);
+        let found: Vec<String> = repo
+            .list_scripts_recursive()
+            .unwrap()
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(found.contains(&"keep.sh".to_string()));
+        assert!(found.contains(&"scripts/visible.sh".to_string()));
+        assert!(!found.contains(&"scripts/local.py".to_string()));
+        assert!(!found.contains(&"scripts/global.tmp.sh".to_string()));
+    }
+
+    #[test]
+    fn test_nested_omakureignore_leading_slash_anchors_to_local_file_dir() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let scripts = root.join("scripts");
+        fs::create_dir_all(scripts.join("nested")).unwrap();
+        fs::write(scripts.join("scratch.py"), "print('scratch')").unwrap();
+        fs::write(scripts.join("nested/scratch.py"), "print('nested')").unwrap();
+        fs::write(scripts.join(".omakureignore"), "/scratch.py\n").unwrap();
+
+        let repo = FsWorkspaceRepository::new(root);
+        let found: Vec<String> = repo
+            .list_scripts_recursive()
+            .unwrap()
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(!found.contains(&"scripts/scratch.py".to_string()));
+        assert!(found.contains(&"scripts/nested/scratch.py".to_string()));
+    }
+
+    #[test]
+    fn test_list_entries_outside_root_still_uses_root_ignore_only() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("root");
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(root.join(".omakureignore"), "hidden.sh\n").unwrap();
+        fs::write(outside.join("hidden.sh"), "#!/bin/bash").unwrap();
+
+        let repo = FsWorkspaceRepository::new(&root);
+        let entries = repo.list_entries(&outside).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, outside.join("hidden.sh"));
     }
 
     #[test]

--- a/src/adapters/workspace_repository.rs
+++ b/src/adapters/workspace_repository.rs
@@ -57,8 +57,8 @@ impl ScriptRepository for FsWorkspaceRepository {
 
     fn list_scripts_recursive(&self) -> io::Result<Vec<PathBuf>> {
         let mut scripts = Vec::new();
-        let ignore = IgnoreContext::load_for_dir(&self.root, &self.root);
-        collect_scripts(&self.root, &ignore, &mut scripts)?;
+        let mut ignore = IgnoreContext::load_for_dir(&self.root, &self.root);
+        collect_scripts(&self.root, &mut ignore, &mut scripts)?;
         Ok(scripts)
     }
 
@@ -80,7 +80,7 @@ impl ScriptRepository for FsWorkspaceRepository {
 
 fn collect_scripts(
     dir: &Path,
-    ignore: &IgnoreContext,
+    ignore: &mut IgnoreContext,
     scripts: &mut Vec<PathBuf>,
 ) -> io::Result<()> {
     let entries = read_dir_or_empty(dir)?;
@@ -91,8 +91,12 @@ fn collect_scripts(
             if should_skip_dir(&path) || ignore.matches(&path, true) {
                 continue;
             }
-            let child_ignore = ignore.with_dir(&path);
-            collect_scripts(&path, &child_ignore, scripts)?;
+            let pushed = ignore.push_dir(&path);
+            let result = collect_scripts(&path, ignore, scripts);
+            if pushed {
+                ignore.pop_dir();
+            }
+            result?;
         } else if path.is_file() && script_kind(&path).is_some() && !ignore.matches(&path, false) {
             scripts.push(path);
         }
@@ -101,7 +105,7 @@ fn collect_scripts(
     Ok(())
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 struct IgnoreContext {
     files: Vec<OmakureIgnore>,
 }
@@ -110,28 +114,33 @@ impl IgnoreContext {
     fn load_for_dir(root: &Path, dir: &Path) -> Self {
         let mut context = Self::default();
         let Ok(rel) = dir.strip_prefix(root) else {
-            return context.with_dir(root);
+            context.push_dir(root);
+            return context;
         };
 
-        context = context.with_dir(root);
+        context.push_dir(root);
         let mut cursor = root.to_path_buf();
         for component in rel.components() {
             let std::path::Component::Normal(part) = component else {
                 continue;
             };
             cursor.push(part);
-            context = context.with_dir(&cursor);
+            context.push_dir(&cursor);
         }
         context
     }
 
-    fn with_dir(&self, dir: &Path) -> Self {
-        let mut next = self.clone();
+    fn push_dir(&mut self, dir: &Path) -> bool {
         let ignore = OmakureIgnore::load(dir);
         if !ignore.patterns.is_empty() {
-            next.files.push(ignore);
+            self.files.push(ignore);
+            return true;
         }
-        next
+        false
+    }
+
+    fn pop_dir(&mut self) {
+        self.files.pop();
     }
 
     fn matches(&self, path: &Path, is_dir: bool) -> bool {
@@ -139,13 +148,13 @@ impl IgnoreContext {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 struct OmakureIgnore {
     root: PathBuf,
     patterns: Vec<IgnorePattern>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct IgnorePattern {
     pattern: String,
     anchored: bool,


### PR DESCRIPTION
## Summary
- load .omakureignore rules from the session root through the directory being listed or recursively scanned
- apply parent and child ignore rules together so child script folders stay hidden when Omakure starts from a parent directory
- update docs to describe nested .omakureignore behavior and local-relative slash patterns
- replace recursive context cloning with push/pop traversal to avoid accumulated pattern copies per directory

## Validation
- rtk cargo test workspace_repository::tests
- rtk cargo test search_index::tests::test_rebuild_honors_omakureignore
- rtk cargo fmt && rtk cargo test && rtk mise run lint && rtk git diff --check
- rtk cargo tarpaulin --out Xml --output-dir /tmp/opencode/omakure-coverage-1764-final

## Risk
- Blast radius: medium; affects TUI navigation, omakure scripts, search indexing, and scheduler discovery through the shared scanner.
- Rollback: revert the two branch commits and rebuild/reinstall if a local binary has been installed.