### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "omakure"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omakure"
-version = "0.1.9"
+version = "0.2.0"
 repository = "https://github.com/This-Is-NPC/omakure"
 license = "AGPL-3.0-only"
 edition = "2021"

--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -1,0 +1,39 @@
+# v0.2.0
+
+## Highlights
+- Active environment files now inject runtime variables into scripts across the TUI, `omakure run`, and queue workers.
+- `omakure run --env-file` adds per-run environment overrides with explicit precedence and safe variable expansion.
+- Virtual environments now work predictably by resolving interpreters against the injected `PATH`.
+- `.omakureignore` support keeps helpers, fixtures, generated files, and nested workspaces out of script scanning surfaces.
+
+## Added
+- Runtime env injection from the active `.omaken/envs/<name>.conf` into spawned script processes.
+- `omakure run --env-file <path>` for one-off environment injection on top of the managed active env.
+- Case-preserving env parser for runtime injection, keeping variables such as `PATH` and `VIRTUAL_ENV` intact.
+- Single-pass `$VAR` and `${VAR}` expansion for env values, including inherited parent shell variables as expansion sources.
+- Absolute interpreter resolution against the injected `PATH`, enabling venv-style Python, Node, Ruby, and other toolchain shims.
+- `omakure config` diagnostics for resolved active-env keys and the interpreter path Omakure will execute.
+- `.omakureignore` scanning for the TUI, `omakure scripts`, search index, and scheduler.
+- `.docs/env-injection-spec.md` documenting env precedence, expansion grammar, and secret non-persistence.
+
+## Changed
+- Active env files now affect script runtime behavior, not only TUI schema-field defaults.
+- Env precedence is now explicit: parent shell env < active env < `--env-file` < Omakure-reserved variables.
+- `PATH=/x/bin:$PATH` style values now expand against the inherited/merged environment instead of self-referencing raw file values.
+- Config and environment previews now mask sensitive values with `****`.
+- Project workflow documentation now points to Omakiten for task shaping, planning, and execution instead of the removed assisted-workflow scaffolding.
+
+## Fixed
+- Nested `.omakureignore` files are now evaluated relative to the directory where each ignore file is declared.
+- Opening a parent scripts directory no longer exposes files ignored by a child workspace's own `.omakureignore`.
+- Env-file expansion no longer drops the parent shell `PATH` or leaves literal `$PATH` residue when prepending paths.
+- User-provided env values can no longer override reserved `OMAKURE_RUN_ID` and `OMAKURE_SCRIPTS_DIR` values.
+- Secret diagnostics now mask additional sensitive keys and URLs containing embedded credentials.
+
+## Chores
+- Removed legacy assisted-workflow templates and `.workflow` scaffolding.
+- Added `.temp/` to `.gitignore`.
+- Added regression coverage for command path resolution, env injection, secret masking, `.omakureignore`, and nested ignore traversal.
+- Bumped package version to `0.2.0`.
+- Added release notes required by the `release-ready` CI job.
+- Validated local release readiness with tests, lint, formatting, Linux release build, and package extraction.


### PR DESCRIPTION
## Summary
- bump Cargo package version to 0.2.0
- add release notes for changes currently staged on test before master release

## Validation
- rtk cargo test
- rtk cargo fmt --check
- rtk cargo clippy -- -D warnings