### PR TITLE
feat(api): add HTTP management API

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -17,6 +17,7 @@ Start here if you want a map of the docs. For quick start and requirements, see 
 ## For AI integrators
 
 - `ai-interface.md`: JSON envelope contract, AI-facing verbs, error codes, data shapes.
+- `cli-http-parity.md`: implemented CLI, operations, and HTTP parity matrix.
 
 ## For contributors
 
@@ -25,4 +26,4 @@ Start here if you want a map of the docs. For quick start and requirements, see 
 - `requirements.md`: implemented functional/non-functional/business rules (file-referenced).
 - `release-artifacts.md`: release archive naming requirements.
 - `tui-screens-and-widgets.md`: TUI screen flow, per-screen keybindings, and widget inventory.
-- `env-injection-spec.md`: env precedence table, var-expansion grammar, and the secret-non-persistence invariant (gates injection/parser work).
+- `env-injection-spec.md`: implemented env precedence table, var-expansion grammar, and the secret-non-persistence invariant.

--- a/.docs/ai-interface.md
+++ b/.docs/ai-interface.md
@@ -75,9 +75,9 @@ breaks the privacy contract for no benefit.
 
 For deployments where the agent is sandboxed in a container or
 restricted user account (the canonical pattern for orchestrating an
-AI agent fleet), the privacy contract should be backed by
-**kernel-enforced isolation**, not just by documentation. Recommended
-pattern:
+AI agent fleet), the privacy contract can be backed by
+**kernel-enforced isolation**, not just by documentation. Hardened
+deployment pattern:
 
 1. Mount `<workspace>/.history/` into the sandbox so the omakure
    binary can reach it, but make it owned by a UID **other than** the
@@ -177,13 +177,13 @@ On failure:
 | `script_exists`            | `omakure init` would overwrite without `--force`          |
 | `missing_required_field`   | `run --no-prompt` and a required field has no `--<flag>`  |
 | `invalid_argument`         | Argument value cannot be parsed (e.g. bad `--since`)      |
-| `not_implemented`          | Reserved feature not available in this version            |
+| `not_implemented`          | Existing flag or platform path is intentionally unsupported |
 | `internal`                 | Catch-all for I/O / SQLite / unexpected errors            |
 
 ## Verbs
 
-The AI surface is intentionally small. Five commands cover the discover →
-describe → create → run → audit loop.
+The AI surface is the set of CLI commands that emit the stable JSON envelope
+through `--json`, plus `help-ai` which is always JSON.
 
 ### `omakure help-ai`
 
@@ -381,14 +381,14 @@ omakure --json history show 1700000000000-12345-0
 omakure --json history tail --limit 5
 ```
 
-`history tail --follow` is reserved for a future release and currently
-returns `error.code = "not_implemented"`.
+`history tail --follow` is accepted as a flag but currently returns
+`error.code = "not_implemented"`; `tail` is a snapshot command.
 
 ### `omakure config --json`
 
 Returns the resolved workspace root, scripts root, history dir, envs
 dir, active environment, and bootstrap mode in one envelope. Useful for
-agents that need to find `.history/runs.sqlite` directly.
+agents that need to understand which workspace a command will operate on.
 
 ## `run_id` format
 
@@ -650,18 +650,17 @@ omakure scripts --json --tag prefeitura --tag sp
 omakure search prefeitura --json --tag production
 ```
 
-## Cron producer contract
+## Scheduler producer contract
 
-The future omakure cron scheduler will produce work by calling
-`omakure queue add` with the new `--cron-schedule-id` flag (and
-`--actor cron`). The flag stores its value on the row's
-`cron_schedule_id` column so cron-originated rows can be distinguished
-from agent-originated rows by a `WHERE cron_schedule_id IS NOT NULL`
-query.
+`omakure serve` scans enabled script `Schedule` blocks and enqueues due runs
+through the same run state machine used by `omakure queue add`. Scheduled rows
+use `trigger = Scheduled`, `actor = scheduler`, `reason = "cron: <expr>"`, and
+`cron_schedule_id = <canonical_path>@<cron_expr>`.
 
-**No cron scheduler implementation ships in this release.** Only the
-schema column and the documented producer contract are added now so a
-future cron release does not require a schema migration.
+The `--cron-schedule-id` flag on `omakure queue add` records the same
+provenance field for manual replay or external producers. Rows with a non-null
+`cron_schedule_id` participate in the scheduler overlap check when the id
+matches the scheduler's `<canonical_path>@<cron_expr>` format.
 
 ## Worked example: agent fleet pushing work
 
@@ -695,16 +694,13 @@ omakure --json queue dead-letter "$RUN_ID" --reason "captcha solver broken"
 omakure --json history stats
 ```
 
-## Out of scope (v1)
+## Current boundaries
 
-- The cron scheduler itself (only the schema column and producer
-  contract are added now).
 - Automatic retry policies (`retrying` state, exponential backoff,
   retry limits). Manual re-enqueue is the only retry mechanism.
 - Job dependencies / DAGs.
 - Multi-host coordination.
-- Embedded MCP server. CLI is the v1 contract; an MCP shim over these
-  same verbs may be added later without re-designing the contract.
+- Embedded MCP server. CLI and HTTP are the implemented integration surfaces.
 - Streaming `run --json` output. Long-running scripts still print live
   output when `--json` is **not** set.
 - `history tail --follow` and trace tail / follow mode. Both are

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -72,6 +72,13 @@ src/
 ├── ports/                      Trait definitions (interfaces)
 │   ├── mod.rs                  ScriptRepository, ScriptRunner
 │   └── environment.rs          EnvironmentRepository, EnvironmentConfig
+├── operations/                 Protocol-neutral use-case operations shared by CLI/HTTP
+│   ├── core.rs                 Workspace, scripts, runs, queue state operations
+│   ├── config.rs               Full config/env/interpreter diagnostics contract
+│   ├── search.rs               Shared script search operation
+│   ├── scripts.rs              Safe tree/content browsing operations
+│   ├── doctor.rs               Structured diagnostics report
+│   └── battery.rs              Battery registry/sync/install/remove operations
 ├── adapters/                   Concrete implementations
 │   ├── workspace_repository.rs Filesystem-based ScriptRepository
 │   ├── script_runner.rs        MultiScriptRunner (bash/ps1/py command construction)
@@ -117,6 +124,7 @@ tests/                          Integration tests (cli_positional_path.rs)
 ## Architectural Patterns
 
 - **Hexagonal (Ports & Adapters):** `domain/` has no I/O; `ports/` defines traits (`ScriptRepository`, `ScriptRunner`, `EnvironmentRepository`); `adapters/` holds concrete impls. Composition happens in `use_cases/` and `cli/`.
+- **Operations as Protocol Boundary:** `src/operations/*` is the canonical behavior layer for CLI, HTTP, and future protocols. Operations own validation, path confinement, state-machine calls, and stable operation errors. CLI modules render human/JSON output; HTTP handlers handle auth, query/body parsing, status mapping, and envelopes. New protocol surfaces should call operations rather than CLI modules or direct storage adapters.
 - **SQLite as Runtime Source of Truth:** Every runtime fact (queue, history, traces, schedules) lives in `<workspace>/.history/runs.sqlite`. Config stays on disk; state stays in SQLite.
 - **Run State Machine:** `runs.rs` gates transitions between `queued`, `running`, `completed`, `failed`, `cancelled`, `timed_out`, `dead_letter` via typed helpers (`enqueue`, `start_inline`, `claim_next`, `complete`, `fail`, `cancel`, `time_out`, `dead_letter`, `heartbeat`). Illegal moves return `invalid_argument`. `claim_next` uses a single atomic `UPDATE … RETURNING`.
 - **Single Execution Code Path:** `omakure run`, `omakure queue worker`, and the scheduler-enqueued rows all flow through `run_executor::execute_with_heartbeat`. The helper spawns the child with `OMAKURE_RUN_ID`, refreshes the 60 s lease every 250 ms, reacts to mid-run cancel/timeout, and drains stdout/stderr via bounded mpsc channels so orphan grandchildren never deadlock the executor.

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -99,6 +99,8 @@ src/
     ├── json.rs                 Single envelope writer + stable error codes
     ├── run.rs                  omakure run
     ├── queue.rs                omakure queue add|cancel|dead-letter|worker|stats
+    ├── api.rs                  omakure api (loopback HTTP management API)
+    ├── battery.rs              omakure battery list|add|sync|inspect|scripts|install|remove
     ├── serve.rs                omakure serve (cron scheduler daemon + lock + tick loop)
     ├── serve_autostart.rs      systemd user unit install/uninstall/status (Linux-only)
     ├── history.rs              omakure history list|show|tail|stats|traces
@@ -124,7 +126,7 @@ tests/                          Integration tests (cli_positional_path.rs)
 ## Architectural Patterns
 
 - **Hexagonal (Ports & Adapters):** `domain/` has no I/O; `ports/` defines traits (`ScriptRepository`, `ScriptRunner`, `EnvironmentRepository`); `adapters/` holds concrete impls. Composition happens in `use_cases/` and `cli/`.
-- **Operations as Protocol Boundary:** `src/operations/*` is the canonical behavior layer for CLI, HTTP, and future protocols. Operations own validation, path confinement, state-machine calls, and stable operation errors. CLI modules render human/JSON output; HTTP handlers handle auth, query/body parsing, status mapping, and envelopes. New protocol surfaces should call operations rather than CLI modules or direct storage adapters.
+- **Operations as Protocol Boundary:** `src/operations/*` is the canonical behavior layer shared by the CLI and HTTP adapter. Operations own validation, path confinement, state-machine calls, and stable operation errors. CLI modules render human/JSON output; HTTP handlers handle auth, query/body parsing, status mapping, and envelopes.
 - **SQLite as Runtime Source of Truth:** Every runtime fact (queue, history, traces, schedules) lives in `<workspace>/.history/runs.sqlite`. Config stays on disk; state stays in SQLite.
 - **Run State Machine:** `runs.rs` gates transitions between `queued`, `running`, `completed`, `failed`, `cancelled`, `timed_out`, `dead_letter` via typed helpers (`enqueue`, `start_inline`, `claim_next`, `complete`, `fail`, `cancel`, `time_out`, `dead_letter`, `heartbeat`). Illegal moves return `invalid_argument`. `claim_next` uses a single atomic `UPDATE … RETURNING`.
 - **Single Execution Code Path:** `omakure run`, `omakure queue worker`, and the scheduler-enqueued rows all flow through `run_executor::execute_with_heartbeat`. The helper spawns the child with `OMAKURE_RUN_ID`, refreshes the 60 s lease every 250 ms, reacts to mid-run cancel/timeout, and drains stdout/stderr via bounded mpsc channels so orphan grandchildren never deadlock the executor.
@@ -146,7 +148,7 @@ tests/                          Integration tests (cli_positional_path.rs)
 - **CI/CD:** GitHub Actions
   - `ci.yml` (PRs targeting `master`): `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and release-readiness gate.
   - `release.yml`: matrix build (Linux x86_64, macOS x86_64, Windows x86_64) → tar.gz/zip → upload to GitHub Releases.
-  - `auto-release.yml`: triggered on merge to `main` to auto-bump patch + tag + fire `release.yml`.
+  - `auto-release.yml`: triggered when a PR is merged into `master`; reads the current `Cargo.toml` version, requires matching release notes, creates the tag, and invokes `release.yml`.
 - **Task Runner (`mise.toml`):** `tui`, `dev` (build + daemon + TUI), `daemon-start`, `daemon-stop`, `daemon-log`, `build`, `test`, `lint`, `install`, `coverage` (tarpaulin).
 - **Two Binaries:** `omakure` (main TUI + CLI) and `omakure-installer` (standalone installer).
 - **Install Scripts:** `install.sh`, `install.ps1`, `install-from-source.sh` at the repo root (public `curl | bash` entrypoints).

--- a/.docs/batteries.md
+++ b/.docs/batteries.md
@@ -4,9 +4,10 @@ A Battery is an external Omakure-compatible automation repository registered
 with a local Omakure workspace. Battery repositories are untrusted input until a
 user explicitly installs selected scripts into the trusted scripts workspace.
 
-This document defines the Battery v1 contract. HTTP management endpoints are
-out of scope for v1; the Battery operations are designed so a future HTTP layer
-can call the same operation functions as the CLI.
+This document defines the Battery v1 contract. The HTTP management API is a
+transport adapter over the same Battery operations as the CLI, with the extra
+restriction that HTTP Battery registration and HTTP-triggered Battery use are
+limited to `https://` sources.
 
 ## Scope
 
@@ -24,7 +25,6 @@ All commands support the global `--json` flag.
 
 ## Non-Goals
 
-- No HTTP endpoint, API server, authentication middleware, or route handler.
 - No Omaken compatibility layer, migration, alias, or fallback behavior.
 - No direct execution from a Battery cache checkout.
 - No submodule checkout by default.
@@ -175,11 +175,13 @@ The initial operation error taxonomy is intentionally small:
 CLI JSON output uses the existing envelope shape where practical:
 
 ```json
-{ "ok": true, "data": {}, "error": null, "schema_version": 1 }
+{ "ok": true, "data": {}, "error": null, "schema_version": "1" }
 ```
 
-## Future HTTP Handoff
+## HTTP Adapter
 
-The future HTTP layer should be a transport adapter over these same operations.
-It should not shell out to `omakure` and should not reimplement Battery safety
-logic in route handlers.
+The HTTP layer is a transport adapter over these same operations. It does not
+shell out to `omakure` and does not reimplement Battery safety logic in route
+handlers. HTTP applies a narrower source policy than the local CLI: Batteries
+created or used through HTTP must have `https://` Git URLs. Local paths,
+`file://`, and plaintext `http://` sources remain CLI-only.

--- a/.docs/batteries.md
+++ b/.docs/batteries.md
@@ -46,8 +46,8 @@ Battery metadata is Omakure-owned runtime state and lives under `.omakure/`.
 └── omakure.toml
 ```
 
-`batteries.json` is the registry. It is versioned so future schema changes can
-be migrated deliberately.
+`batteries.json` is the registry. The current registry format has
+`"version": 1`.
 
 ```json
 {
@@ -70,7 +70,7 @@ Rules:
 - `name` is the stable Battery id used by CLI and operation requests.
 - `cache_path` is stored relative to the workspace root.
 - `resolved_commit` is empty until the first successful sync.
-- Writes to the registry should be atomic where practical.
+- Writes to the registry are performed through the Battery operations layer.
 - A malformed registry is an operation error, not a silent reset.
 
 ## Repository Format
@@ -129,8 +129,8 @@ Rules:
   `.omakure/batteries/installed/`, keyed by Battery name and script id.
 - A failed install must not leave a partial target file when the target did not
   previously exist.
-- A forced overwrite should write through a temporary file and rename into
-  place where practical.
+- A forced overwrite replaces the existing target only after the selected
+  Battery script has passed validation.
 
 ## Remove Contract
 
@@ -142,7 +142,7 @@ Rules:
 
 - Registry entry removal is required.
 - Cache deletion happens only with `--remove-cache`.
-- Installed script deletion is out of scope for v1.
+- Removing a Battery does not delete installed scripts.
 - Removing an unknown Battery returns a stable not-found operation error.
 
 ## Operation Boundary

--- a/.docs/cli-http-parity.md
+++ b/.docs/cli-http-parity.md
@@ -1,0 +1,67 @@
+# CLI / HTTP parity
+
+This document records the CLI surfaces that currently have equivalent behavior
+through shared operations and the HTTP management API.
+
+## Legend
+
+| Status | Meaning |
+|---|---|
+| Full | HTTP exposes the same core behavior through shared operations. |
+| Partial | HTTP exposes a safe subset or equivalent workflow. |
+| CLI-only | The command is inherently local CLI behavior. |
+
+## Implemented parity
+
+| CLI | Operation | HTTP | Status | Notes |
+|---|---|---|---|---|
+| `omakure config --json` | `config_summary` | `GET /v1/config` | Full | HTTP redacts active env values. |
+| workspace summary | `workspace_summary` | `GET /v1/workspace` | Full | HTTP client workspace metadata. |
+| `omakure doctor` | `doctor_report` | `GET /v1/doctor` | Full | CLI human output differs. |
+| `omakure scripts --json` | `list_scripts` | `GET /v1/scripts` | Full | Shared tag filtering. |
+| `omakure describe <script> --json` | `describe_script` | `GET /v1/scripts/{script_id}` | Full | Shared path resolution and schema errors. |
+| schema projection | `describe_script` | `GET /v1/scripts/{script_id}/schema` | Full | HTTP convenience projection. |
+| script tree browsing | `list_tree` | `GET /v1/tree`, `GET /v1/tree/{path}` | Full | HTTP-only safe browsing surface. |
+| script content read | `read_script_content` | `GET /v1/scripts/{script_id}/content` | Full | UTF-8 only, 1 MiB cap, metadata paths blocked. |
+| `omakure search <query> --json` | `search_scripts` | `GET /v1/search?q=...` | Partial | HTTP uses existing index and caps query/tag input. |
+| `omakure history list --json` | `list_runs` | `GET /v1/runs` | Full | Shared filters. |
+| `omakure history show <run_id> --json` | `show_run` | `GET /v1/runs/{run_id}` | Full | Stable missing-run errors. |
+| `omakure history traces <run_id> --json` | `list_traces` | `GET /v1/runs/{run_id}/traces` | Full | Shared trace filters. |
+| `omakure history stats --json` | `run_stats` | `GET /v1/queue/stats` | Partial | Same data, queue-named HTTP route. |
+| `omakure queue stats --json` | `queue_stats` | `GET /v1/queue/stats` | Full | Same aggregate as history stats. |
+| `omakure queue add <script> --json` | `enqueue_run` | `POST /v1/runs` | Full | HTTP exposes enqueue, not inline run. |
+| `omakure queue cancel <run_id> --json` | `cancel_run` | `POST /v1/runs/{run_id}/cancel` | Full | Shared state transition. |
+| `omakure queue dead-letter <run_id> --json` | `dead_letter_run` | `POST /v1/runs/{run_id}/dead-letter` | Full | Shared state transition. |
+| `omakure battery list --json` | `list_batteries` | `GET /v1/batteries` | Full | Shared Battery operation. |
+| `omakure battery add <url> --json` | `add_battery` | `POST /v1/batteries` | Partial | HTTP accepts HTTPS sources only. |
+| `omakure battery sync <name> --json` | `sync_battery` | `POST /v1/batteries/{battery_id}/sync` | Full | Shared operation. |
+| `omakure battery inspect <name> --json` | `inspect_battery` | `GET /v1/batteries/{battery_id}` | Full | Shared operation. |
+| `omakure battery scripts <name> --json` | `list_battery_scripts` | `GET /v1/batteries/{battery_id}/scripts` | Full | Shared operation. |
+| `omakure battery install <name> <script-id> --json` | `install_battery_script` | `POST /v1/batteries/{battery_id}/scripts/{script_id}/install` | Full | Shared operation. |
+| `omakure battery remove <name> --json` | `remove_battery` | `DELETE /v1/batteries/{battery_id}` | Full | Supports `remove_cache` query option. |
+
+## Not exposed over HTTP
+
+| CLI | Reason |
+|---|---|
+| `omakure help-ai` | Capability discovery is a local CLI JSON surface. |
+| `omakure theme list|preview|path` | Theme discovery reads local theme files and is exposed only by CLI/TUI. |
+| `omakure theme set <name>` | Mutates global user config. |
+| `omakure serve --status` | systemd user-unit inspection is local host process state. |
+| `omakure history stats --json` | Same aggregate is exposed through `GET /v1/queue/stats`; there is no separate `/v1/runs/stats` route. |
+| `omakure run <script>` | Inline synchronous execution is CLI/TUI-only. HTTP enqueues with `POST /v1/runs`. |
+| `omakure init <script>` | Script creation is local CLI-only. |
+| `omakure trace` | Trace writes are script-authored CLI calls using `OMAKURE_RUN_ID`. |
+| `omakure serve` lifecycle | Host process control is CLI-only. |
+| `omakure queue worker` | Long-running daemon process, not request/response API behavior. |
+| `omakure update` | Replaces binary and copies release scripts. |
+| `omakure uninstall` | Destructive local operation. |
+
+## CLI-only surfaces
+
+| CLI | Reason |
+|---|---|
+| TUI launch | Interactive terminal UI. |
+| TUI positional path | Session-only local UI behavior. |
+| `omakure api` | Starts the HTTP server itself. |
+| `omakure completion <shell>` | Shell integration emitted to local stdout. |

--- a/.docs/development.md
+++ b/.docs/development.md
@@ -77,4 +77,4 @@ PID file at `<workspace>/.omakure/daemon.pid`, structured log at
 
 - `.github/workflows/ci.yml` runs on every PR to `master`: `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`, release-readiness gate.
 - `.github/workflows/release.yml` builds the cross-platform matrix and attaches release archives.
-- `.github/workflows/auto-release.yml` bumps patch + tags on merge to `main`, triggering the release workflow.
+- `.github/workflows/auto-release.yml` runs when a PR is merged into `master`, reads the current `Cargo.toml` version, requires matching release notes, creates the tag, and triggers the release workflow.

--- a/.docs/env-injection-spec.md
+++ b/.docs/env-injection-spec.md
@@ -1,28 +1,19 @@
 # Environment injection spec
 
-This is the **written contract** that gates all environment-injection and
-env-file-parser code. It fixes three decisions that cross-cut every
-downstream task so no implementer re-decides them:
+This is the implemented environment-injection contract. It documents three
+behaviors shared by `omakure run`, the TUI run path, and `queue worker`:
 
 1. the **precedence table** — the canonical merge order of env sources;
 2. the **var-expansion grammar** — how `$VAR` / `${VAR}` are substituted;
 3. the **secret-non-persistence invariant** — injected env reaches the
    spawned process only, never storage.
 
-Downstream tasks implement *from* this document:
-
-- **1753** — env-file parser (`--env-file` / `.conf` reader)
-- **1754** — injector (merge + apply precedence, build `extra_env`)
-- **1755** — interpreter (var-expansion engine)
-- **1756** — CLI surface (`--env-file` flag wiring)
-
 Terminology: "env" means the ordered set of `KEY=value` pairs that will be
 handed to a script process. "Merged env" means the single map produced
 after all precedence layers have been folded together. Keys are compared
 **case-sensitively** at injection time (unlike the TUI-defaults parser in
 `src/adapters/environments.rs`, which lowercases keys to match schema
-fields — that path is unrelated to process injection and is out of scope
-here).
+fields — that path is unrelated to process injection).
 
 ---
 
@@ -53,29 +44,23 @@ key survives*.
   injected *last*, so a user variable of the same name from layers 1–3
   **cannot** clobber them. If a user defines `OMAKURE_RUN_ID` in their
   shell or `.conf` or `--env-file`, the omakure value still wins. The
-  injector MUST guarantee reserved keys are the final writes into the
-  merged map (never merged first and then risk being overwritten).
+  injector writes reserved keys last into the merged map.
 - Reserved-key values are authoritative:
   - `OMAKURE_RUN_ID` = the run's `run_id`.
   - `OMAKURE_SCRIPTS_DIR` = the workspace root (so nested `omakure trace`
     calls resolve the same `runs.sqlite`).
 - This mirrors the existing injection in `src/run_executor.rs`
   (`execute_with_heartbeat`), where the reserved pair is pushed onto the
-  `env` vec **after** the caller-supplied `extra_env` (currently lines
-  ~103–111). Downstream layers 2 and 3 are new inputs that feed
-  `extra_env`; the reserved-last ordering established there is the
-  contract and must be preserved.
+  `env` vec **after** the caller-supplied `extra_env`. Layers 2 and 3 feed
+  `extra_env`; the reserved-last ordering established there is the runtime
+  contract.
 
 ### Notes / edge cases
 
 - The **session `omakure.conf`** override (see `.docs/environments.md`)
-  governs *TUI schema-field defaults*, not process injection, and is out
-  of scope for this spec. If a future task folds it into injection, it
-  slots between layers 2 and 3 and MUST be specified in a follow-up; it
-  is **not** assumed by tasks 1753–1756.
-- If `--env-file` is given more than once, the resolution of repeated
-  flags (last-wins vs. accumulate) is a CLI decision owned by task 1756;
-  whatever it chooses, the *result* still enters the fold at priority 3.
+  governs *TUI schema-field defaults*, not process injection.
+- `--env-file` is a single optional flag on `omakure run`. The supplied
+  file enters the fold at priority 3.
 
 ---
 
@@ -83,7 +68,7 @@ key survives*.
 
 After the merged env is produced (post-precedence, section 1), each
 **value** may contain references to other variables. The interpreter
-(task 1755) resolves them with the following grammar.
+resolves them with the following grammar.
 
 ### 2.1 Substitution model
 
@@ -97,9 +82,7 @@ After the merged env is produced (post-precedence, section 1), each
   (layer 3). Crucially this **includes the parent shell env (layer 1)**: a
   reference like `$PATH` resolves to the inherited parent value, so a
   self-referencing value such as `PATH=/x/bin:$PATH` prepends to the
-  existing PATH rather than referencing the file's own raw value (which
-  would double the prefix and leave a literal `$PATH`). References MUST NOT
-  be expanded against only the current file's own keys.
+  existing PATH rather than referencing the file's own raw value.
 - **Reserved vars are not expansion sources.** `OMAKURE_RUN_ID` and
   `OMAKURE_SCRIPTS_DIR` are injected last by `execute_with_heartbeat` after
   layer-2/layer-3 expansion has already completed. A `.conf` or
@@ -136,8 +119,7 @@ letters, digits, or underscores). The braced form `${...}` accepts the
   `$1` → literal `$1`; `$ ` → literal `$ `.
 - A malformed brace with no closing `}` (e.g. `${FOO`) is **emitted
   literally** — the interpreter does not treat an unterminated `${` as a
-  reference. (Downstream MAY additionally surface a parse warning, but
-  the defined behavior is literal passthrough.)
+  reference.
 
 ### 2.3 Undefined variables
 
@@ -161,27 +143,24 @@ letters, digits, or underscores). The braced form `${...}` accepts the
     scan for `\$` as a two-character unit first; any other `\` is a
     literal character with no special meaning.
 
-### 2.5 Explicitly forbidden / out of scope
+### 2.5 Explicitly forbidden
 
-The following are **not interpreted** and MUST NOT be implemented as
-active behavior by task 1755:
+The following are **not interpreted**:
 
 - **Command substitution** — `$(...)` and backtick `` `...` `` forms are
   **forbidden**. They are treated as literal text (a `$` before `(` is
   not a valid reference start, so `$(date)` emits literally as
   `$(date)`). No subprocess is ever spawned by the expander.
 - **Recursion / re-scanning** of expansion output (see 2.1).
-- **Rich bash-style expansions**, explicitly out of scope:
+- **Rich bash-style expansions**, unsupported:
   `${VAR:-default}`, `${VAR:=default}`, `${VAR:?err}`, `${VAR:+alt}`,
   `${#VAR}`, `${VAR/foo/bar}`, `${VAR^^}`, indirection `${!VAR}`,
   arithmetic `$((...))`, and any array/parameter operators. If such a
   form appears, the `${...}` body is taken as a *name* and matched
   against the name charset; because these bodies contain characters
-  outside `[A-Za-z0-9_]`, they will not match a defined variable and
+  outside `[A-Za-z0-9_]`, they do not match a defined variable and
   therefore resolve per the undefined rule (empty) unless the body
-  happens to be a bare valid name. Downstream tasks SHOULD NOT rely on
-  any particular handling of these bodies beyond "not a rich
-  expansion."
+  happens to be a bare valid name.
 
 ### 2.6 Worked examples
 
@@ -226,42 +205,38 @@ it**:
 
 1. **Injection point** — `src/run_executor.rs`,
    `execute_with_heartbeat(...)`: the `extra_env: Vec<(String, String)>`
-   parameter is moved into a local `env` vec; the reserved pair is pushed
-   (~lines 103–111); the vec is handed to
-   `MultiScriptRunner::build_command(&script_path, &args, &env)`
-   (~line 113). It is never inserted into any `RunRow` and never passed
-   to any `runs::*` writer.
+   parameter is moved into a local `env` vec; the reserved pair is pushed;
+   the vec is handed to
+   `MultiScriptRunner::build_command(&script_path, &args, &env)`. It is
+   never inserted into any `RunRow` and never passed to any `runs::*`
+   writer.
 
 2. **Spawn point** — `src/adapters/script_runner.rs`,
-   `MultiScriptRunner::build_command(script, args, env)` (line 27): each
-   pair is applied via `cmd.env(k, v)` (lines 35–37). This is the *only*
-   consumer of the env. The resulting `Command` is spawned in
+   `MultiScriptRunner::build_command(script, args, env)`: each pair is
+   applied via `cmd.env(k, v)`. This is the *only* consumer of the env.
+   The resulting `Command` is spawned in
    `run_executor.rs` (`command.spawn()`); the env exists solely inside
    the child process from that point on.
 
 3. **Persistence point (env-free by construction)** — `src/runs.rs`,
-   `insert_run(conn, row)` (line 548) executes
-   `INSERT INTO runs (...)` (lines 550–556). The `runs` table schema
-   (`init_schema`, lines 490–515) has columns for
-   `args_json, actor, reason, state, ..., stdout, stderr, error,
-   omakure_version` and so on — **there is no `env` column and no
-   `extra_env` field on `RunRow`.** The env cannot be persisted here
-   because there is nowhere to put it. Trace rows go to `run_traces`
-   (`init_schema` lines 525–535; writer `INSERT INTO run_traces` at
-   `src/runs.rs` ~line 1232) which stores `level, message, data_json` and
-   likewise has no env sink.
+   `insert_run(conn, row)` executes `INSERT INTO runs (...)`. The `runs`
+   table schema has columns for `args_json, actor, reason, state, ...,
+   stdout, stderr, error, omakure_version` and so on — **there is no `env`
+   column and no `extra_env` field on `RunRow`.** The env cannot be
+   persisted here because there is nowhere to put it. Trace rows go to
+   `run_traces`, which stores `level, message, data_json` and likewise has
+   no env sink.
 
 4. **Masking (defense in depth, TUI preview only)** —
-   `src/adapters/environments.rs`, `is_sensitive_key(key)` (line 236)
-   flags keys containing `password`, `secret`, `token`, `key`, `api`,
+   `src/adapters/environments.rs`, `is_sensitive_key(key)` flags keys
+   containing `password`, `secret`, `token`, `key`, `api`,
    `private`, or `cred`, and the Environments **preview** masks their
    values with `***`. This is a *display* control for the `.conf` preview
    pane, independent of injection; it is **not** the mechanism that keeps
-   secrets out of storage (that is guaranteed structurally by points
-   1–3). Downstream code MUST NOT rely on masking as the persistence
-   guard.
+   secrets out of storage (that is guaranteed structurally by points 1–3).
+   Code must not rely on masking as the persistence guard.
 
-### Rules for downstream tasks
+### Rules for code changes
 
 - **Do not add an `env` / `extra_env` column** to the `runs` table or any
   field carrying env to `RunRow`, `RunCompletion`, or any `runs::*`
@@ -270,9 +245,8 @@ it**:
   values** — not via `println!`/`eprintln!`, not via the trace
   (`run_traces`), not via any structured logger. The env must have
   exactly one consumer: `cmd.env(...)` in `build_command`.
-- Any new diagnostic that wants to surface *which keys* were injected MAY
-  log **key names only**, never values, and SHOULD apply
-  `is_sensitive_key` if it ever prints anything derived from a value.
+- Diagnostics that surface injected env information log **key names only**,
+  never values, and apply the same sensitivity rules used by env previews.
 
 ### Residual exposure (accepted tradeoff)
 
@@ -287,16 +261,3 @@ OS-level exposure, which is **acknowledged and accepted, not fixed**:
 These are inherent to passing secrets through process environment and are
 an accepted tradeoff for this feature. Callers who cannot tolerate this
 exposure should not route secrets through env injection.
-
----
-
-## Acceptance checklist (for downstream reviewers)
-
-- [ ] Injector folds sources in order 1→2→3→4; later layer wins per key.
-- [ ] `OMAKURE_RUN_ID` / `OMAKURE_SCRIPTS_DIR` applied last and cannot be
-      overridden by layers 1–3.
-- [ ] Expander is single-pass, non-recursive, sourced from merged env.
-- [ ] Undefined → empty string; `\$` is the only escape; no command
-      substitution; no `${VAR:-default}` support.
-- [ ] No `env` column / field added to persistence; `extra_env` never
-      logged or traced; `cmd.env` is its sole consumer.

--- a/.docs/how-to-create-a-script.md
+++ b/.docs/how-to-create-a-script.md
@@ -73,7 +73,7 @@ daemon scans scripts at start and enqueues runs at the declared times with
   a macro (`@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`). `@reboot`
   is rejected. Invalid expressions fail script load.
 - `Enabled`: defaults to `true` when omitted. Toggle it from the TUI
-  Schedules screen (press `c` from the main screen, then `Space`).
+  Schedules screen (press `Ctrl+/` then `c`, then `Space`).
 
 Scheduled fires build `--<arg> <default>` from each field's declared
 default. Fields without a default are skipped. If the previous run for a
@@ -149,4 +149,3 @@ prompt_if_empty TARGET "Target (optional)"
 # 4) Main
 printf "Running with target=%s\n" "${TARGET}"
 ```
-

--- a/.docs/http-api.md
+++ b/.docs/http-api.md
@@ -119,6 +119,7 @@ Error mapping:
 | invalid input / validation | 400 |
 | not found | 404 |
 | conflict / invalid transition / unsynced Battery | 409 |
+| unsupported script/content media | 415 |
 | payload too large | 413 |
 | unsupported operation | 501 |
 | internal I/O or unexpected error | 500 |
@@ -141,10 +142,16 @@ GET /v1/health
 Read endpoints require auth:
 
 ```http
+GET /v1/config
+GET /v1/doctor
 GET /v1/workspace
+GET /v1/search
+GET /v1/tree
+GET /v1/tree/{path}
 GET /v1/scripts
 GET /v1/scripts/{script_id}
 GET /v1/scripts/{script_id}/schema
+GET /v1/scripts/{script_id}/content
 GET /v1/runs
 GET /v1/runs/{run_id}
 GET /v1/runs/{run_id}/traces
@@ -213,13 +220,35 @@ HTTP Battery registration accepts `https://` Git URLs only. Local paths,
 `file://`, and plaintext `http://` sources remain outside the HTTP API trust
 boundary; use the local CLI for local development sources.
 
+Read query parameters and safety policy:
+
+- `GET /v1/config` returns the full config shape, but HTTP masks every active
+  environment value. Plaintext env diagnostics are CLI-only.
+- `GET /v1/search?q=<query>&tag=<tag>` searches scripts using the existing
+  SQLite index. HTTP does not rebuild the index per request. `query` is accepted
+  as an alias for `q`; repeated `tag` parameters are AND-filtered. Empty queries
+  are rejected. Query length is capped at 256 bytes; tags are capped at 16 total
+  and 64 bytes each.
+- `GET /v1/tree/{path}` lists directories/scripts under the scripts root. It
+  honors nested `.omakureignore` files through the shared workspace repository.
+  Listings are capped at 1000 entries.
+- `GET /v1/scripts/{script_id}/content` returns UTF-8 script content only.
+  Content is capped at 1 MiB, must be a supported script type, and cannot escape
+  the scripts root through `..`, absolute paths, or symlinks.
+- Tree/content routes reject `.omakure`, `.history`, and `.git` metadata paths.
+
 ## CLI / HTTP Parity Matrix
 
 | CLI | HTTP | Shared operation |
 |---|---|---|
-| `omakure config --json` | `GET /v1/workspace` | `workspace_summary` |
+| `omakure config --json` | `GET /v1/config` | `config_summary` |
+| workspace summary | `GET /v1/workspace` | `workspace_summary` |
 | `omakure scripts --json` | `GET /v1/scripts` | `list_scripts` |
+| `omakure search <query> --json` | `GET /v1/search?q=...` | `search_scripts` |
 | `omakure describe <script> --json` | `GET /v1/scripts/{script_id}` | `describe_script` |
+| script browser | `GET /v1/tree`, `GET /v1/tree/{path}` | `list_tree` |
+| script content | `GET /v1/scripts/{script_id}/content` | `read_script_content` |
+| `omakure doctor` | `GET /v1/doctor` | `doctor_report` |
 | `omakure history list --json` | `GET /v1/runs` | `list_runs` |
 | `omakure history show <run_id> --json` | `GET /v1/runs/{run_id}` | `show_run` |
 | `omakure history traces <run_id> --json` | `GET /v1/runs/{run_id}/traces` | `list_traces` |
@@ -239,7 +268,12 @@ boundary; use the local CLI for local development sources.
 
 HTTP routes call shared operations for these core resources:
 
+- `config_summary`
+- `doctor_report`
 - `workspace_summary`
+- `search_scripts`
+- `list_tree`
+- `read_script_content`
 - `list_scripts`
 - `describe_script`
 - `script_schema` via the `describe_script` operation output
@@ -253,6 +287,17 @@ HTTP routes call shared operations for these core resources:
 
 These operations own validation and stable errors. HTTP route handlers must not
 call CLI modules and must not open SQLite directly.
+
+The following surfaces are intentionally deferred from HTTP until a separate
+security/lifecycle design exists:
+
+- `omakure update`: mutates binary/scripts from a remote release.
+- `omakure uninstall`: destructive local operation.
+- `omakure serve`: daemon lifecycle management.
+- `omakure queue worker`: long-running process lifecycle.
+- inline `omakure run`: synchronous execution surface; use `POST /v1/runs` to
+  enqueue instead.
+- HTTP trace ingestion: changes the trust model for script-authored telemetry.
 
 ## Write Audit Expectations
 

--- a/.docs/http-api.md
+++ b/.docs/http-api.md
@@ -1,9 +1,6 @@
 # HTTP API Contract
 
-This is the v1 contract for Omakure's internal HTTP management API. It is
-the implementation source for the `http-management-api` plan and reconciles
-the older `.temp/plan.md` brief with the current codebase: Omaken is gone,
-and Battery CLI/operations already exist.
+This is the v1 contract for Omakure's internal HTTP management API.
 
 ## Goal
 
@@ -34,7 +31,7 @@ Why:
 - Middleware and extractors keep auth, body limits, and route state testable.
 - `tower` service testing lets endpoint tests run without binding real ports.
 - The async runtime is contained behind `omakure api`; existing CLI/TUI code
-  remains synchronous unless an operation already needs async in a later task.
+  remains synchronous.
 
 ## Command Contract
 
@@ -284,12 +281,18 @@ HTTP routes call shared operations for these core resources:
 - `enqueue_run`
 - `cancel_run`
 - `dead_letter_run`
+- `list_batteries`
+- `add_battery`
+- `sync_battery`
+- `inspect_battery`
+- `list_battery_scripts`
+- `install_battery_script`
+- `remove_battery`
 
-These operations own validation and stable errors. HTTP route handlers must not
-call CLI modules and must not open SQLite directly.
+These operations own validation and stable errors. HTTP route handlers do not
+call CLI modules and do not open SQLite directly.
 
-The following surfaces are intentionally deferred from HTTP until a separate
-security/lifecycle design exists:
+The current HTTP API does not expose these CLI surfaces:
 
 - `omakure update`: mutates binary/scripts from a remote release.
 - `omakure uninstall`: destructive local operation.
@@ -297,14 +300,14 @@ security/lifecycle design exists:
 - `omakure queue worker`: long-running process lifecycle.
 - inline `omakure run`: synchronous execution surface; use `POST /v1/runs` to
   enqueue instead.
-- HTTP trace ingestion: changes the trust model for script-authored telemetry.
+- HTTP trace ingestion.
 
 ## Write Audit Expectations
 
-V1 write endpoints must leave an audit trail equivalent to their CLI
+V1 write endpoints leave an audit trail equivalent to their CLI
 operation path. At minimum, writes must create or transition rows through the
-existing run state machine or Battery registry/provenance records. Future
-structured HTTP request logs may be added, but they must redact bearer tokens.
+existing run state machine or Battery registry/provenance records. HTTP errors
+and responses redact bearer tokens.
 
 ## Deployment Model
 
@@ -349,15 +352,11 @@ Operational safety notes:
 - Queue/run writes use the existing SQLite run state machine; invalid state
   transitions return `conflict` instead of bypassing the workflow.
 
-## Validation Gates
+## Validation
 
-Every HTTP implementation task must pass:
+Use the normal repository checks after changing the HTTP API:
 
 ```bash
-rtk cargo test
-rtk mise run lint
+cargo test
+mise run lint
 ```
-
-Before shipping the full API plan, run an assurance pass that includes at
-least auth bypass, bind guard, token leakage, request-size, operation parity,
-and Battery trust-boundary checks.

--- a/.docs/http-api.md
+++ b/.docs/http-api.md
@@ -1,0 +1,318 @@
+# HTTP API Contract
+
+This is the v1 contract for Omakure's internal HTTP management API. It is
+the implementation source for the `http-management-api` plan and reconciles
+the older `.temp/plan.md` brief with the current codebase: Omaken is gone,
+and Battery CLI/operations already exist.
+
+## Goal
+
+Expose Omakure through a small internal HTTP API in the same binary so a
+trusted local process, sidecar, or internal-network container can manage a
+workspace without shelling out to the CLI.
+
+HTTP is an adapter. It must not own business logic. Each route translates an
+HTTP request into a shared operation request, calls `src/operations/*`, then
+serializes the operation result.
+
+## Non-Goals
+
+- Public internet API.
+- Browser-facing CORS support.
+- OAuth, OIDC, sessions, users, or RBAC.
+- Distributed queue across hosts.
+- Shared SQLite over network filesystems.
+- Direct execution of Battery scripts from Git cache.
+- A second product surface with behavior that differs from CLI operations.
+
+## Framework Decision
+
+Use `axum` with `tokio` for v1.
+
+Why:
+
+- Middleware and extractors keep auth, body limits, and route state testable.
+- `tower` service testing lets endpoint tests run without binding real ports.
+- The async runtime is contained behind `omakure api`; existing CLI/TUI code
+  remains synchronous unless an operation already needs async in a later task.
+
+## Command Contract
+
+```bash
+omakure api --bind 127.0.0.1:7878
+omakure api --bind 0.0.0.0:7878 --allow-non-loopback
+```
+
+Defaults and guards:
+
+- Default bind: `127.0.0.1:7878`.
+- Loopback bind is allowed without extra flags.
+- Non-loopback bind requires `--allow-non-loopback`.
+- `0.0.0.0` and `::` count as non-loopback.
+- Binding must fail before listening when the guard is not satisfied.
+
+## Authentication Contract
+
+Every endpoint except health requires:
+
+```http
+Authorization: Bearer <token>
+```
+
+Token source:
+
+- `OMAKURE_API_TOKEN`
+
+Rules:
+
+- Reject missing token configuration before serving protected endpoints.
+- Reject an empty token.
+- Reject known default/example tokens such as `changeme`, `password`,
+  `secret`, `token`, and `omakure`.
+- Require a minimum token length of 32 bytes.
+- Compare presented and configured tokens in constant time where practical.
+- Redact token values from logs, errors, JSON responses, and tests fixtures.
+- Never inject `OMAKURE_API_TOKEN` into script environments.
+- CORS is disabled by default. Do not add permissive CORS in v1.
+
+## Request Limits
+
+Apply a request body limit before JSON extraction.
+
+V1 limit: 1 MiB.
+
+Rationale: the API accepts small management requests, not artifact uploads.
+
+## JSON Envelope
+
+HTTP responses use the same envelope shape as CLI JSON where practical:
+
+```json
+{
+  "ok": true,
+  "data": {},
+  "error": null,
+  "schema_version": "1"
+}
+```
+
+Error response:
+
+```json
+{
+  "ok": false,
+  "data": null,
+  "error": {
+    "code": "not_found",
+    "message": "resource was not found"
+  },
+  "schema_version": "1"
+}
+```
+
+Error mapping:
+
+| Error family | HTTP status |
+|---|---:|
+| auth missing/invalid | 401 |
+| forbidden bind/config policy | 403 |
+| invalid input / validation | 400 |
+| not found | 404 |
+| conflict / invalid transition / unsynced Battery | 409 |
+| payload too large | 413 |
+| unsupported operation | 501 |
+| internal I/O or unexpected error | 500 |
+
+Operation-specific errors keep their stable operation code, such as
+`not_synced`, `manifest_invalid`, `unsafe_path`, `git_failed`, or
+`registry_invalid`.
+
+The implemented v1 server uses the same envelope helper as CLI JSON output.
+`schema_version` is a string for parity with CLI responses.
+
+## Endpoint Contract
+
+Health is unauthenticated:
+
+```http
+GET /v1/health
+```
+
+Read endpoints require auth:
+
+```http
+GET /v1/workspace
+GET /v1/scripts
+GET /v1/scripts/{script_id}
+GET /v1/scripts/{script_id}/schema
+GET /v1/runs
+GET /v1/runs/{run_id}
+GET /v1/runs/{run_id}/traces
+GET /v1/queue/stats
+GET /v1/batteries
+GET /v1/batteries/{battery_id}
+GET /v1/batteries/{battery_id}/scripts
+```
+
+Write endpoints require auth:
+
+```http
+POST /v1/runs
+POST /v1/runs/{run_id}/cancel
+POST /v1/runs/{run_id}/dead-letter
+POST /v1/batteries
+POST /v1/batteries/{battery_id}/sync
+POST /v1/batteries/{battery_id}/scripts/{script_id}/install
+DELETE /v1/batteries/{battery_id}
+```
+
+`POST /v1/runs` enqueues by default. It does not block on inline execution.
+
+Write request bodies:
+
+```json
+POST /v1/runs
+{
+  "script": "tools/job",
+  "args": ["--flag"],
+  "run_id": "optional-caller-id",
+  "actor": "agent",
+  "reason": "why this was queued",
+  "priority": 10,
+  "timeout_ms": 60000,
+  "parent_run_id": null,
+  "cron_schedule_id": null
+}
+```
+
+Defaults: `args=[]`, `actor="human"`, `priority=0`.
+
+```json
+POST /v1/runs/{run_id}/cancel
+{ "reason": "optional" }
+
+POST /v1/runs/{run_id}/dead-letter
+{ "reason": "optional" }
+
+POST /v1/batteries
+{
+  "name": "azure",
+  "git_url": "https://example.invalid/azure.git",
+  "requested_ref": "main"
+}
+
+POST /v1/batteries/{battery_id}/scripts/{script_id}/install
+{ "force": false }
+```
+
+Battery defaults: `requested_ref="main"`, `force=false`, and
+`DELETE /v1/batteries/{battery_id}` defaults to keeping the cache. Add
+`?remove_cache=true` to delete the cached clone while unregistering.
+
+HTTP Battery registration accepts `https://` Git URLs only. Local paths,
+`file://`, and plaintext `http://` sources remain outside the HTTP API trust
+boundary; use the local CLI for local development sources.
+
+## CLI / HTTP Parity Matrix
+
+| CLI | HTTP | Shared operation |
+|---|---|---|
+| `omakure config --json` | `GET /v1/workspace` | `workspace_summary` |
+| `omakure scripts --json` | `GET /v1/scripts` | `list_scripts` |
+| `omakure describe <script> --json` | `GET /v1/scripts/{script_id}` | `describe_script` |
+| `omakure history list --json` | `GET /v1/runs` | `list_runs` |
+| `omakure history show <run_id> --json` | `GET /v1/runs/{run_id}` | `show_run` |
+| `omakure history traces <run_id> --json` | `GET /v1/runs/{run_id}/traces` | `list_traces` |
+| `omakure queue stats --json` | `GET /v1/queue/stats` | `queue_stats` |
+| `omakure queue add <script> --json` | `POST /v1/runs` | `enqueue_run` |
+| `omakure queue cancel <run_id> --json` | `POST /v1/runs/{run_id}/cancel` | `cancel_run` |
+| `omakure queue dead-letter <run_id> --json` | `POST /v1/runs/{run_id}/dead-letter` | `dead_letter_run` |
+| `omakure battery list --json` | `GET /v1/batteries` | `list_batteries` |
+| `omakure battery add <url> --json` | `POST /v1/batteries` | `add_battery` |
+| `omakure battery sync <name> --json` | `POST /v1/batteries/{battery_id}/sync` | `sync_battery` |
+| `omakure battery inspect <name> --json` | `GET /v1/batteries/{battery_id}` | `inspect_battery` |
+| `omakure battery scripts <name> --json` | `GET /v1/batteries/{battery_id}/scripts` | `list_battery_scripts` |
+| `omakure battery install <name> <script-id> --json` | `POST /v1/batteries/{battery_id}/scripts/{script_id}/install` | `install_battery_script` |
+| `omakure battery remove <name> --json` | `DELETE /v1/batteries/{battery_id}` | `remove_battery` |
+
+## Shared Operations
+
+HTTP routes call shared operations for these core resources:
+
+- `workspace_summary`
+- `list_scripts`
+- `describe_script`
+- `script_schema` via the `describe_script` operation output
+- `list_runs`
+- `show_run`
+- `list_traces`
+- `queue_stats`
+- `enqueue_run`
+- `cancel_run`
+- `dead_letter_run`
+
+These operations own validation and stable errors. HTTP route handlers must not
+call CLI modules and must not open SQLite directly.
+
+## Write Audit Expectations
+
+V1 write endpoints must leave an audit trail equivalent to their CLI
+operation path. At minimum, writes must create or transition rows through the
+existing run state machine or Battery registry/provenance records. Future
+structured HTTP request logs may be added, but they must redact bearer tokens.
+
+## Deployment Model
+
+Loopback mode:
+
+```bash
+export OMAKURE_API_TOKEN="$(openssl rand -hex 32)"
+omakure api
+```
+
+Internal container network mode:
+
+```bash
+export OMAKURE_API_TOKEN="$(openssl rand -hex 32)"
+omakure api --bind 0.0.0.0:7878 --allow-non-loopback
+```
+
+Publishing the API to a host port is a deployment choice outside v1's safety
+guarantees. Do not document this as public-internet safe.
+
+Container/internal-network guidance:
+
+- Prefer loopback for local tools and sidecars on the same host.
+- Use `--allow-non-loopback` only when another trusted process cannot reach
+  loopback, such as a private container network.
+- Put network policy, firewall rules, or reverse-proxy ACLs in front of any
+  non-loopback bind.
+- Do not enable permissive browser CORS in v1.
+- Do not expose this API directly to the public internet; v1 has no OAuth,
+  RBAC, sessions, or browser threat model.
+
+Operational safety notes:
+
+- Keep `OMAKURE_API_TOKEN` out of scripts and environment files used by scripts.
+- Rotate the token like any other management secret.
+- Request bodies are limited to 1 MiB.
+- Battery cache content is still untrusted. HTTP can list, sync, inspect, and
+  install through Battery operations, but cannot execute scripts directly from
+  `.omakure/batteries/cache/`.
+- HTTP Battery registration is restricted to `https://` sources, so non-loopback
+  token holders cannot ask the server to import arbitrary local repositories.
+- Queue/run writes use the existing SQLite run state machine; invalid state
+  transitions return `conflict` instead of bypassing the workflow.
+
+## Validation Gates
+
+Every HTTP implementation task must pass:
+
+```bash
+rtk cargo test
+rtk mise run lint
+```
+
+Before shipping the full API plan, run an assurance pass that includes at
+least auth bypass, bind guard, token leakage, request-size, operation parity,
+and Battery trust-boundary checks.

--- a/.docs/release-artifacts.md
+++ b/.docs/release-artifacts.md
@@ -1,13 +1,10 @@
 # Release artifact format
 
-Artifacts must follow the pattern below (version in the filename):
+The current release workflow builds these artifacts (version in the filename):
 
 - `omakure-vX.Y.Z-linux-x86_64.tar.gz`
-- `omakure-vX.Y.Z-linux-aarch64.tar.gz`
 - `omakure-vX.Y.Z-darwin-x86_64.tar.gz`
-- `omakure-vX.Y.Z-darwin-aarch64.tar.gz`
 - `omakure-vX.Y.Z-windows-x86_64.zip`
-- `omakure-vX.Y.Z-windows-aarch64.zip`
 
 Archives must contain the binary at the root of the archive:
 

--- a/.docs/requirements.md
+++ b/.docs/requirements.md
@@ -66,6 +66,10 @@
 | FR-061 | TUI Activity Grid widget renders a time-bucketed heatmap of run density (per-script or per-workspace) from `app.history.entries` | `src/adapters/tui/widgets/activity_grid.rs` |
 | FR-062 | History Dashboards view (`Tab` on History) renders a BarChart of runs by state, a 14-day Sparkline of runs per day, and a per-script panel with a Canvas pie chart + duration sparkline (avg/p50/p95). `e`/`Enter` expands the per-script panel; narrow panels fall back to a horizontal stacked "ribbon" bar | `src/adapters/tui/widgets/dashboards.rs`, `src/adapters/tui/state/history.rs` (`HistoryView`) |
 | FR-063 | `update --version <TAG>` flag is preserved against clap's auto-generated `--version` by disabling the auto flag on `UpdateArgs`; `--repo` defaults to `$OMAKURE_REPO` / `$OVERTURE_REPO` / `$CLOUD_MGMT_REPO` / `$REPO` / `This-Is-NPC/omakure`; `--version` defaults to `$VERSION` or the latest GitHub release | `src/cli/args.rs` (`UpdateArgs` with `disable_version_flag`), `src/cli/update.rs` (`resolve_repo`, `resolve_version`) |
+| FR-064 | Per-run environment injection: `omakure run --env-file <PATH>` parses case-preserving `KEY=value` pairs, expands `$VAR`/`${VAR}` single-pass, overlays the managed active env, and injects the merged env into the spawned process only | `src/cli/run.rs`, `src/cli/args.rs` (`RunArgs.env_file`), `src/adapters/environments.rs` (`resolve_run_env`, `parse_env_file`, `expand_env_value`) |
+| FR-065 | Omakure-reserved runtime env vars `OMAKURE_RUN_ID` and `OMAKURE_SCRIPTS_DIR` are injected last by the shared executor and cannot be overridden by active env or `--env-file` values | `src/run_executor.rs` (`execute_with_heartbeat`), `src/adapters/script_runner.rs` (`MultiScriptRunner::build_command`) |
+| FR-066 | Battery CLI registers, syncs, inspects, lists, installs, and removes reusable Omakure-compatible automation repositories through shared Battery operations; cached checkouts remain untrusted and scripts are copied into the trusted workspace only through `battery install` | `src/cli/battery.rs`, `src/operations/battery.rs` |
+| FR-067 | Internal HTTP management API: `omakure api` starts an Axum server with `/v1/health`, config/doctor/workspace/search/tree/scripts/runs/queue-stats/Battery endpoints, CLI-compatible JSON envelopes, shared operation calls, bearer auth, and loopback-by-default binding | `src/cli/api.rs`, `src/cli/args.rs` (`ApiArgs`), `src/operations/*` |
 
 ## Non-Functional Requirements
 
@@ -77,10 +81,12 @@
 | NFR-004 | Graceful terminal restore on TUI exit (raw-mode cleanup) | `src/main.rs` (`run_tui`), `src/adapters/tui/mod.rs` |
 | NFR-005 | Schema cache to avoid re-parsing on repeated selection | `src/adapters/tui/app.rs` (`load_schema`, `schema_cache`) |
 | NFR-006 | Centralized error hierarchy with typed errors (`AppError`, `SchemaError`, `ScriptError`, `EnvironmentError`) mapped to stable JSON codes | `src/error.rs`, `src/cli/json.rs` |
-| NFR-007 | Automated release pipeline: PR merge triggers version bump, tag, cross-platform build, and GitHub Release | `.github/workflows/auto-release.yml`, `.github/workflows/release.yml` |
+| NFR-007 | Automated release pipeline: PR merge to `master` reads the current `Cargo.toml` version, requires matching release notes, creates the version tag, builds cross-platform release artifacts, and publishes a GitHub Release | `.github/workflows/auto-release.yml`, `.github/workflows/release.yml` |
 | NFR-008 | PR-gate CI (`ci.yml`) runs `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and a release-readiness check on every pull request | `.github/workflows/ci.yml` |
 | NFR-009 | Scheduler never fork-bombs the queue: all fires go through the same `runs::enqueue` state machine as manual runs, so worker concurrency, cancel semantics, and lease reclamation are shared | `src/cli/serve.rs`, `src/runs.rs` |
 | NFR-010 | In-process worker pool within `omakure serve` is opt-in via `--no-worker = false` (default); pool size is `--concurrency` (default 1). Workers cooperate with the same SIGINT/SIGTERM handler as `queue worker` so the daemon drains in-flight work on shutdown | `src/cli/serve.rs` (`run_scheduler`), `src/cli/queue.rs` (`worker_loop`, `install_signal_handlers`) |
+| NFR-011 | HTTP API management access requires `Authorization: Bearer <token>` for every endpoint except `/v1/health`; `OMAKURE_API_TOKEN` must be present, at least 32 bytes, and not a known default; comparisons use a token digest and constant-time equality | `src/cli/api.rs` (`token_from_env`, `require_bearer`, `token_digest_for`) |
+| NFR-012 | HTTP request bodies are capped at 1 MiB and Battery registration through HTTP accepts `https://` sources only | `src/cli/api.rs` (`BODY_LIMIT_BYTES`, `add_battery_handler`, `sanitize_battery_for_http`) |
 
 ## Business Rules
 
@@ -99,3 +105,5 @@
 | BR-011 | Systemd autostart unit name is FNV-1a hash of the canonical workspace path, ensuring multiple workspaces don't collide on the same machine; deterministic across invocations | `src/cli/serve_autostart.rs` (`path_hash`, `unit_name`) |
 | BR-012 | TUI in-place `Schedule.Enabled` toggle never reserializes the user's JSON block; only the `"Enabled"` value inside the `OMAKURE_SCHEMA_START`/`END` span is rewritten, and the round-trip through `parse_schema` is verified before the write is persisted | `src/adapters/tui/app.rs` (`rewrite_schedule_enabled`, `toggle_schedule_enabled_in_file`) |
 | BR-013 | `runs.trigger` defaults to `Manual` for legacy rows written before the column existed (migration backfills with `DEFAULT 'Manual'` on rebuild) | `src/runs.rs` (`rebuild_legacy_schema_if_needed`, `init_schema`) |
+| BR-014 | Injected env values are never persisted in `runs.sqlite`, daemon logs, or run traces; the merged env is passed only to `Command::env` at spawn time | `src/run_executor.rs`, `src/adapters/script_runner.rs`, `src/runs.rs` |
+| BR-015 | Battery operations reject unsafe manifest paths, unsupported script extensions, invalid schemas, and symlinks before exposing or installing scripts | `src/operations/battery.rs` |

--- a/.docs/scheduling.md
+++ b/.docs/scheduling.md
@@ -51,7 +51,7 @@ attach it to. Unknown macros and malformed expressions fail script load
 with `error.code = "schema_invalid"`.
 
 `Enabled` defaults to `true` when omitted. Toggle in place from the TUI
-Schedules screen (`c` from the main menu, `Space` on the row).
+Schedules screen (`Ctrl+/` then `c`, `Space` on the row).
 
 ## Running the scheduler
 

--- a/.docs/tui-screens-and-widgets.md
+++ b/.docs/tui-screens-and-widgets.md
@@ -1,7 +1,7 @@
 # TUI screens and widgets
 
 Inventory of every screen and widget in the TUI layer. Use it to navigate the
-code, plan refactors, or map user-visible behavior to its source.
+code or map user-visible behavior to its source.
 
 Source locations:
 

--- a/.docs/usage.md
+++ b/.docs/usage.md
@@ -112,13 +112,81 @@ Lifecycle:
 - `remove` unregisters the Battery; `--remove-cache` also deletes the cached
   clone. Installed scripts are left in the trusted workspace.
 
-HTTP handoff: future endpoints should wrap the same operations backing these
-commands (`list_batteries`, `add_battery`, `sync_battery`, `inspect_battery`,
+HTTP endpoints wrap the same operations backing these commands
+(`list_batteries`, `add_battery`, `sync_battery`, `inspect_battery`,
 `list_battery_scripts`, `install_battery_script`, `remove_battery`) rather than
-shelling out or duplicating safety logic.
+shelling out or duplicating safety logic. HTTP Battery registration is stricter:
+it accepts `https://` sources only.
 
 See `batteries.md` for repository format, safety rules, install provenance, and
 validation expectations.
+
+## HTTP API
+
+The internal HTTP management API runs in the same binary and wraps the same
+shared operations as the CLI. V1 is scoped as a trusted management surface,
+not a public internet API.
+
+Loopback mode:
+
+```bash
+export OMAKURE_API_TOKEN="$(openssl rand -hex 32)"
+omakure api
+```
+
+Internal container/private-network mode:
+
+```bash
+export OMAKURE_API_TOKEN="$(openssl rand -hex 32)"
+omakure api --bind 0.0.0.0:7878 --allow-non-loopback
+```
+
+Safety model:
+
+- default bind is loopback (`127.0.0.1:7878`),
+- non-loopback bind requires explicit opt-in,
+- every endpoint except health requires `Authorization: Bearer <token>`,
+- request bodies are limited to 1 MiB,
+- route handlers call shared operations instead of CLI modules,
+- no CORS/OAuth/RBAC/browser support is provided in v1,
+- Battery cache scripts are never executed directly by HTTP.
+- HTTP Battery registration accepts `https://` sources only; local paths and
+  `file://` sources are CLI-only.
+
+Quick check:
+
+```bash
+curl http://127.0.0.1:7878/v1/health
+curl -H "Authorization: Bearer $OMAKURE_API_TOKEN" \
+  http://127.0.0.1:7878/v1/scripts
+```
+
+Implemented endpoints:
+
+```text
+GET    /v1/health
+GET    /v1/workspace
+GET    /v1/scripts
+GET    /v1/scripts/{script_id}
+GET    /v1/scripts/{script_id}/schema
+GET    /v1/runs
+GET    /v1/runs/{run_id}
+GET    /v1/runs/{run_id}/traces
+GET    /v1/queue/stats
+POST   /v1/runs
+POST   /v1/runs/{run_id}/cancel
+POST   /v1/runs/{run_id}/dead-letter
+GET    /v1/batteries
+POST   /v1/batteries
+POST   /v1/batteries/{battery_id}/sync
+GET    /v1/batteries/{battery_id}
+GET    /v1/batteries/{battery_id}/scripts
+POST   /v1/batteries/{battery_id}/scripts/{script_id}/install
+DELETE /v1/batteries/{battery_id}
+```
+
+See `http-api.md` for JSON request bodies, error/status mapping, deployment
+guidance, and the CLI/HTTP/shared-operation parity matrix.
 
 ## Config / env
 

--- a/.docs/usage.md
+++ b/.docs/usage.md
@@ -165,10 +165,16 @@ Implemented endpoints:
 
 ```text
 GET    /v1/health
+GET    /v1/config
+GET    /v1/doctor
 GET    /v1/workspace
+GET    /v1/search
+GET    /v1/tree
+GET    /v1/tree/{path}
 GET    /v1/scripts
 GET    /v1/scripts/{script_id}
 GET    /v1/scripts/{script_id}/schema
+GET    /v1/scripts/{script_id}/content
 GET    /v1/runs
 GET    /v1/runs/{run_id}
 GET    /v1/runs/{run_id}/traces

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,16 +95,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -121,6 +202,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cassowary"
@@ -250,6 +337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +365,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -286,6 +382,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "daemonize"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +405,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -384,6 +500,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -480,6 +605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,10 +686,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -733,10 +948,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -754,6 +981,17 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -805,6 +1043,7 @@ dependencies = [
 name = "omakure"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "clap_complete",
@@ -823,10 +1062,15 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_urlencoded",
+ "sha2",
  "signal-hook",
+ "subtle",
  "tempfile",
  "thiserror",
+ "tokio",
  "toml",
+ "tower",
  "winreg",
 ]
 
@@ -876,6 +1120,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -1163,12 +1413,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1194,7 +1478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -1225,6 +1509,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stability"
@@ -1271,6 +1565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1580,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -1308,6 +1614,31 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "libc",
+ "mio 1.1.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1384,6 +1715,60 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,12 @@ signal-hook = "0.3"
 rattles = "0.2.2"
 cron = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+axum = "0.7"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }
+serde_urlencoded = "0.7"
+subtle = "2.6"
+sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ no browser CORS support, OAuth/RBAC, or public-internet threat model. HTTP
 Battery registration accepts `https://` sources only; local Battery sources are
 CLI-only.
 
+The API exposes config, doctor, search, safe tree/content browsing, scripts,
+runs/queue, and Battery management through `src/operations/*`; route handlers
+must stay adapters, not second implementations.
+
 > **Upgrading from an older release deletes legacy `.history/*.json`
 > files and rebuilds `runs.sqlite` if its schema is older than the
 > state-machine release.** Back up `.history/` first if you care about

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ you point it at.
 - Exclude files from scanning with `.omakureignore`: `.docs/scripts-path.md`
 - Environment documents and defaults: `.docs/environments.md`
 - Attach reusable script repositories with Batteries: `.docs/batteries.md`
+- Internal HTTP management API contract: `.docs/http-api.md`
 - Lua widgets (`index.lua`): `.docs/lua-widgets.md`
 
 ## Using Omakure from an AI agent
@@ -127,8 +128,30 @@ omakure --json battery remove azure --remove-cache
 
 Battery clones are not executable workspace content. Omakure validates manifest
 paths, script extensions, schema blocks, symlinks, and traversal before install.
-Future HTTP endpoints should call the same Battery operations used by the CLI.
-Full contract: `.docs/batteries.md`.
+HTTP Battery endpoints call the same Battery operations used by the CLI, with
+HTTP registration restricted to `https://` sources. Full contract:
+`.docs/batteries.md`.
+
+## HTTP API
+
+The internal HTTP management API is available with `omakure api` and specified
+in `.docs/http-api.md`. It wraps the same shared operations as the CLI and is
+not a public internet API: default bind is loopback, non-loopback requires
+explicit opt-in, and every endpoint except health requires a Bearer token.
+
+```bash
+export OMAKURE_API_TOKEN="$(openssl rand -hex 32)"
+omakure api
+
+curl http://127.0.0.1:7878/v1/health
+curl -H "Authorization: Bearer $OMAKURE_API_TOKEN" \
+  http://127.0.0.1:7878/v1/scripts
+```
+
+Use `--allow-non-loopback` only for trusted internal/container networks. V1 has
+no browser CORS support, OAuth/RBAC, or public-internet threat model. HTTP
+Battery registration accepts `https://` sources only; local Battery sources are
+CLI-only.
 
 > **Upgrading from an older release deletes legacy `.history/*.json`
 > files and rebuilds `runs.sqlite` if its schema is older than the
@@ -146,6 +169,7 @@ Full reference: `.docs/ai-interface.md`.
 - Scripts path overrides: `.docs/scripts-path.md`
 - Environment documents: `.docs/environments.md`
 - Batteries: `.docs/batteries.md`
+- HTTP API contract: `.docs/http-api.md`
 - Lua widgets (`index.lua`): `.docs/lua-widgets.md`
 - CLI usage: `.docs/usage.md`
 - Scheduled tasks (cron daemon): `.docs/scheduling.md`

--- a/src/adapters/script_runner.rs
+++ b/src/adapters/script_runner.rs
@@ -8,6 +8,8 @@ use crate::runtime::{command_for_script, command_for_script_with_env, script_kin
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+const API_TOKEN_ENV: &str = "OMAKURE_API_TOKEN";
+
 pub struct MultiScriptRunner;
 
 impl MultiScriptRunner {
@@ -34,8 +36,11 @@ impl MultiScriptRunner {
         // venv-prepended PATH runs the venv interpreter, not the system one.
         let mut cmd = command_for_script_with_env(script, env)?;
         cmd.args(args);
+        cmd.env_remove(API_TOKEN_ENV);
         for (k, v) in env {
-            cmd.env(k, v);
+            if k != API_TOKEN_ENV {
+                cmd.env(k, v);
+            }
         }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
@@ -64,7 +69,10 @@ impl ScriptRunner for MultiScriptRunner {
     fn run(&self, script: &Path, args: &[String]) -> AppResult<ScriptRunOutput> {
         ensure_runtime_for(script)?;
 
-        let output = command_for_script(script)?.args(args).output()?;
+        let output = command_for_script(script)?
+            .args(args)
+            .env_remove(API_TOKEN_ENV)
+            .output()?;
         Ok(ScriptRunOutput {
             stdout: String::from_utf8_lossy(&output.stdout).to_string(),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
@@ -117,6 +125,20 @@ mod tests {
         assert!(envs
             .iter()
             .any(|(k, v)| *k == "MY_VAR" && *v == Some(std::ffi::OsStr::new("my_value"))));
+    }
+
+    #[test]
+    fn test_build_command_removes_api_token() {
+        let tmp = TempDir::new().unwrap();
+        let script = tmp.path().join("test.sh");
+        fs::write(&script, "#!/bin/bash\necho ok").unwrap();
+
+        let env = vec![(API_TOKEN_ENV.to_string(), "secret".to_string())];
+        let cmd = MultiScriptRunner::build_command(&script, &[], &env).unwrap();
+
+        assert!(cmd
+            .get_envs()
+            .any(|(k, v)| k == API_TOKEN_ENV && v.is_none()));
     }
 
     #[test]

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -1,7 +1,11 @@
 use crate::cli::args::ApiArgs;
 use crate::cli::json;
 use crate::operations::battery as battery_ops;
+use crate::operations::config as config_ops;
 use crate::operations::core;
+use crate::operations::doctor as doctor_ops;
+use crate::operations::scripts as scripts_ops;
+use crate::operations::search as search_ops;
 use crate::operations::{OperationError, OperationErrorCode, OperationResult};
 use crate::workspace::Workspace;
 use axum::body::{to_bytes, Body};
@@ -21,6 +25,9 @@ use subtle::ConstantTimeEq;
 
 const MIN_TOKEN_LEN: usize = 32;
 const BODY_LIMIT_BYTES: usize = 1024 * 1024;
+const MAX_SEARCH_QUERY_LEN: usize = 256;
+const MAX_SEARCH_TAGS: usize = 16;
+const MAX_SEARCH_TAG_LEN: usize = 64;
 
 struct ApiState {
     token_digest: [u8; 32],
@@ -127,7 +134,12 @@ fn router(token: String, workspace: Workspace) -> Router {
     };
     Router::new()
         .route("/v1/health", get(health))
+        .route("/v1/config", get(config_handler))
+        .route("/v1/doctor", get(doctor_handler))
         .route("/v1/workspace", get(workspace_handler))
+        .route("/v1/search", get(search_handler))
+        .route("/v1/tree", get(tree_root_handler))
+        .route("/v1/tree/*path", get(tree_path_handler))
         .route("/v1/scripts", get(list_scripts_handler))
         .route("/v1/scripts/*script_id", get(script_path_handler))
         .route("/v1/runs", get(list_runs_handler).post(enqueue_run_handler))
@@ -173,6 +185,54 @@ async fn workspace_handler(State(state): State<ApiState>) -> Response {
     operation_response(core::workspace_summary(&state.workspace))
 }
 
+async fn config_handler(State(state): State<ApiState>) -> Response {
+    operation_response(config_ops::redacted_config_summary(&state.workspace))
+}
+
+async fn doctor_handler(State(state): State<ApiState>) -> Response {
+    operation_response(doctor_ops::doctor_report(&state.workspace))
+}
+
+async fn search_handler(State(state): State<ApiState>, RawQuery(raw_query): RawQuery) -> Response {
+    let request = query_pairs(raw_query.as_deref()).and_then(|pairs| {
+        let query = query_value(&pairs, "q")
+            .or_else(|| query_value(&pairs, "query"))
+            .ok_or_else(|| {
+                OperationError::new(
+                    OperationErrorCode::InvalidInput,
+                    "q query parameter is required",
+                )
+            })?;
+        if query.trim().is_empty() {
+            return Err(OperationError::new(
+                OperationErrorCode::InvalidInput,
+                "q query parameter must not be empty",
+            ));
+        }
+        if query.len() > MAX_SEARCH_QUERY_LEN {
+            return Err(OperationError::new(
+                OperationErrorCode::InvalidInput,
+                "q query parameter is too long",
+            ));
+        }
+        let tags = query_values(&pairs, "tag");
+        if tags.len() > MAX_SEARCH_TAGS || tags.iter().any(|tag| tag.len() > MAX_SEARCH_TAG_LEN) {
+            return Err(OperationError::new(
+                OperationErrorCode::InvalidInput,
+                "tag query parameters exceed limits",
+            ));
+        }
+        Ok(search_ops::SearchScriptsRequest {
+            query,
+            tags,
+            refresh: false,
+        })
+    });
+    operation_response(
+        request.and_then(|request| search_ops::search_scripts(&state.workspace, request)),
+    )
+}
+
 async fn list_scripts_handler(
     State(state): State<ApiState>,
     RawQuery(raw_query): RawQuery,
@@ -204,12 +264,41 @@ async fn script_path_handler(
     State(state): State<ApiState>,
     AxumPath(script_id): AxumPath<String>,
 ) -> Response {
+    if let Some(script_id) = script_id.strip_suffix("/content") {
+        if !script_id.is_empty() {
+            return script_content_handler(State(state), script_id.to_string()).await;
+        }
+    }
     match script_id.strip_suffix("/schema") {
         Some(script_id) if !script_id.is_empty() => {
             script_schema_handler(State(state), script_id.to_string()).await
         }
         _ => describe_script_handler(State(state), script_id).await,
     }
+}
+
+async fn script_content_handler(State(state): State<ApiState>, script_id: String) -> Response {
+    operation_response(scripts_ops::read_script_content(
+        &state.workspace,
+        scripts_ops::ReadScriptContentRequest { script: script_id },
+    ))
+}
+
+async fn tree_root_handler(State(state): State<ApiState>) -> Response {
+    operation_response(scripts_ops::list_tree(
+        &state.workspace,
+        scripts_ops::ListTreeRequest { path: None },
+    ))
+}
+
+async fn tree_path_handler(
+    State(state): State<ApiState>,
+    AxumPath(path): AxumPath<String>,
+) -> Response {
+    operation_response(scripts_ops::list_tree(
+        &state.workspace,
+        scripts_ops::ListTreeRequest { path: Some(path) },
+    ))
 }
 
 async fn list_runs_handler(
@@ -480,7 +569,7 @@ fn operation_error_response(err: OperationError) -> Response {
         OperationErrorCode::AlreadyExists
         | OperationErrorCode::Conflict
         | OperationErrorCode::NotSynced => StatusCode::CONFLICT,
-        OperationErrorCode::UnsupportedScript => StatusCode::NOT_IMPLEMENTED,
+        OperationErrorCode::UnsupportedScript => StatusCode::UNSUPPORTED_MEDIA_TYPE,
         OperationErrorCode::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
         OperationErrorCode::GitFailed
         | OperationErrorCode::IoFailed
@@ -903,6 +992,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn config_endpoint_returns_full_masked_config() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::write(workspace.envs_dir().join("dev.conf"), "HOST=localhost\n").unwrap();
+        std::fs::write(workspace.envs_active_path(), "dev.conf\n").unwrap();
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/config"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["data"]["version"], app_meta::APP_VERSION);
+        assert_eq!(body["data"]["active_env"], "dev.conf");
+        assert_eq!(body["data"]["active_env_keys"][0]["key"], "HOST");
+        assert_eq!(body["data"]["active_env_keys"][0]["value"], "****");
+        assert!(!body.to_string().contains("localhost"));
+    }
+
+    #[tokio::test]
+    async fn doctor_endpoint_returns_structured_report() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/doctor"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert!(body["data"]["dependencies"].is_array());
+        assert!(body["data"]["workspace_paths"].is_array());
+        assert_eq!(body["data"]["schemas"]["total"], 1);
+    }
+
+    #[tokio::test]
     async fn scripts_and_schema_endpoints_return_operation_data() {
         let dir = TempDir::new().unwrap();
         let workspace = workspace_in(&dir);
@@ -937,6 +1067,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_endpoint_returns_operation_data() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "deploy.sh");
+        search_ops::search_scripts(
+            &workspace,
+            search_ops::SearchScriptsRequest {
+                query: "deploy".into(),
+                tags: vec!["ops".into()],
+                refresh: true,
+            },
+        )
+        .unwrap();
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/search?q=deploy&tag=ops"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["data"][0]["relative_path"], "deploy.sh");
+    }
+
+    #[tokio::test]
+    async fn search_endpoint_requires_query() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/search"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn search_endpoint_rejects_empty_and_oversized_query() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let app = router(TOKEN.to_string(), workspace);
+
+        let empty = app
+            .clone()
+            .oneshot(authed_request("/v1/search?q="))
+            .await
+            .unwrap();
+        assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+
+        let too_long = "x".repeat(MAX_SEARCH_QUERY_LEN + 1);
+        let long = app
+            .oneshot(authed_request(&format!("/v1/search?q={too_long}")))
+            .await
+            .unwrap();
+        assert_eq!(long.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn script_routes_support_nested_paths() {
         let dir = TempDir::new().unwrap();
         let workspace = workspace_in(&dir);
@@ -959,6 +1151,91 @@ mod tests {
         assert_eq!(schema.status(), StatusCode::OK);
         let schema_body = response_json(schema).await;
         assert_eq!(schema_body["data"]["name"], "tools/job.sh");
+    }
+
+    #[tokio::test]
+    async fn tree_and_content_endpoints_return_safe_browsing_data() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "tools/job.sh");
+
+        let app = router(TOKEN.to_string(), workspace);
+        let tree = app
+            .clone()
+            .oneshot(authed_request("/v1/tree"))
+            .await
+            .unwrap();
+        assert_eq!(tree.status(), StatusCode::OK);
+        let tree_body = response_json(tree).await;
+        assert_eq!(tree_body["data"][0]["kind"], "directory");
+        assert_eq!(tree_body["data"][0]["relative_path"], "tools");
+
+        let nested = app
+            .clone()
+            .oneshot(authed_request("/v1/tree/tools"))
+            .await
+            .unwrap();
+        assert_eq!(nested.status(), StatusCode::OK);
+        let nested_body = response_json(nested).await;
+        assert_eq!(nested_body["data"][0]["relative_path"], "tools/job.sh");
+
+        let content = app
+            .oneshot(authed_request("/v1/scripts/tools/job.sh/content"))
+            .await
+            .unwrap();
+        assert_eq!(content.status(), StatusCode::OK);
+        let content_body = response_json(content).await;
+        assert_eq!(content_body["data"]["relative_path"], "tools/job.sh");
+        assert!(content_body["data"]["content"]
+            .as_str()
+            .unwrap()
+            .contains("echo ok"));
+    }
+
+    #[tokio::test]
+    async fn content_endpoint_rejects_path_traversal() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/scripts/../secret.sh/content"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "unsafe_path");
+    }
+
+    #[tokio::test]
+    async fn content_endpoint_rejects_absolute_encoded_path() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/scripts/%2Ftmp%2Fsecret.sh/content"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "unsafe_path");
+    }
+
+    #[tokio::test]
+    async fn content_endpoint_maps_unsupported_script_to_415() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::write(workspace.scripts_root().join("note.txt"), "hello\n").unwrap();
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/scripts/note.txt/content"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "unsupported_script");
     }
 
     #[tokio::test]

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -1,0 +1,1611 @@
+use crate::cli::args::ApiArgs;
+use crate::cli::json;
+use crate::operations::battery as battery_ops;
+use crate::operations::core;
+use crate::operations::{OperationError, OperationErrorCode, OperationResult};
+use crate::workspace::Workspace;
+use axum::body::{to_bytes, Body};
+use axum::extract::{Path as AxumPath, RawQuery, State};
+use axum::http::{header, HeaderMap, Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::env;
+use std::error::Error;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use subtle::ConstantTimeEq;
+
+const MIN_TOKEN_LEN: usize = 32;
+const BODY_LIMIT_BYTES: usize = 1024 * 1024;
+
+struct ApiState {
+    token_digest: [u8; 32],
+    workspace: Workspace,
+}
+
+impl Clone for ApiState {
+    fn clone(&self) -> Self {
+        Self {
+            token_digest: self.token_digest,
+            workspace: self.workspace.clone_for_executor(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ApiConfigError {
+    MissingToken,
+    InvalidToken,
+    NonLoopbackBind(SocketAddr),
+}
+
+impl std::fmt::Display for ApiConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingToken => write!(f, "OMAKURE_API_TOKEN is required"),
+            Self::InvalidToken => write!(f, "OMAKURE_API_TOKEN is invalid"),
+            Self::NonLoopbackBind(addr) => write!(
+                f,
+                "refusing to bind {addr}; pass --allow-non-loopback to opt in"
+            ),
+        }
+    }
+}
+
+impl Error for ApiConfigError {}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnqueueRunBody {
+    script: String,
+    #[serde(default)]
+    args: Vec<String>,
+    run_id: Option<String>,
+    #[serde(default = "default_actor")]
+    actor: String,
+    reason: Option<String>,
+    #[serde(default)]
+    priority: i64,
+    timeout_ms: Option<i64>,
+    parent_run_id: Option<String>,
+    cron_schedule_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RunReasonBody {
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AddBatteryBody {
+    name: String,
+    git_url: String,
+    #[serde(default = "default_battery_ref")]
+    requested_ref: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct InstallBatteryScriptBody {
+    #[serde(default)]
+    force: bool,
+}
+
+fn default_actor() -> String {
+    "human".to_string()
+}
+
+fn default_battery_ref() -> String {
+    "main".to_string()
+}
+
+pub fn run(scripts_dir: PathBuf, args: ApiArgs) -> Result<(), Box<dyn Error>> {
+    validate_bind(args.bind, args.allow_non_loopback)?;
+    let token = token_from_env()?;
+    let workspace = Workspace::new(scripts_dir);
+    workspace.ensure_layout()?;
+
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async move {
+        let listener = tokio::net::TcpListener::bind(args.bind).await?;
+        axum::serve(listener, router(token, workspace)).await?;
+        Ok::<(), Box<dyn Error>>(())
+    })
+}
+
+fn router(token: String, workspace: Workspace) -> Router {
+    let state = ApiState {
+        token_digest: token_digest_for(&token),
+        workspace,
+    };
+    Router::new()
+        .route("/v1/health", get(health))
+        .route("/v1/workspace", get(workspace_handler))
+        .route("/v1/scripts", get(list_scripts_handler))
+        .route("/v1/scripts/*script_id", get(script_path_handler))
+        .route("/v1/runs", get(list_runs_handler).post(enqueue_run_handler))
+        .route("/v1/runs/:run_id", get(show_run_handler))
+        .route("/v1/runs/:run_id/traces", get(list_traces_handler))
+        .route("/v1/runs/:run_id/cancel", post(cancel_run_handler))
+        .route(
+            "/v1/runs/:run_id/dead-letter",
+            post(dead_letter_run_handler),
+        )
+        .route("/v1/queue/stats", get(queue_stats_handler))
+        .route(
+            "/v1/batteries",
+            get(list_batteries_handler).post(add_battery_handler),
+        )
+        .route(
+            "/v1/batteries/:battery_id",
+            get(inspect_battery_handler).delete(remove_battery_handler),
+        )
+        .route(
+            "/v1/batteries/:battery_id/scripts",
+            get(list_battery_scripts_handler),
+        )
+        .route(
+            "/v1/batteries/:battery_id/scripts/:script_id/install",
+            post(install_battery_script_handler),
+        )
+        .route("/v1/batteries/:battery_id/sync", post(sync_battery_handler))
+        .fallback(protected_not_found)
+        .layer(axum::extract::DefaultBodyLimit::max(BODY_LIMIT_BYTES))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_bearer,
+        ))
+        .with_state(state)
+}
+
+async fn health() -> Json<serde_json::Value> {
+    Json(json::ok_envelope(HealthResponse { status: "ok" }))
+}
+
+async fn workspace_handler(State(state): State<ApiState>) -> Response {
+    operation_response(core::workspace_summary(&state.workspace))
+}
+
+async fn list_scripts_handler(
+    State(state): State<ApiState>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let request = query_pairs(raw_query.as_deref()).map(|pairs| core::ListScriptsRequest {
+        tags: query_values(&pairs, "tag"),
+    });
+    operation_response(request.and_then(|request| core::list_scripts(&state.workspace, request)))
+}
+
+async fn describe_script_handler(State(state): State<ApiState>, script_id: String) -> Response {
+    operation_response(core::describe_script(
+        &state.workspace,
+        core::DescribeScriptRequest { script: script_id },
+    ))
+}
+
+async fn script_schema_handler(State(state): State<ApiState>, script_id: String) -> Response {
+    operation_response(
+        core::describe_script(
+            &state.workspace,
+            core::DescribeScriptRequest { script: script_id },
+        )
+        .map(|description| description.schema),
+    )
+}
+
+async fn script_path_handler(
+    State(state): State<ApiState>,
+    AxumPath(script_id): AxumPath<String>,
+) -> Response {
+    match script_id.strip_suffix("/schema") {
+        Some(script_id) if !script_id.is_empty() => {
+            script_schema_handler(State(state), script_id.to_string()).await
+        }
+        _ => describe_script_handler(State(state), script_id).await,
+    }
+}
+
+async fn list_runs_handler(
+    State(state): State<ApiState>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let request = list_runs_request(raw_query.as_deref());
+    operation_response(request.and_then(|request| core::list_runs(&state.workspace, request)))
+}
+
+async fn show_run_handler(
+    State(state): State<ApiState>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    operation_response(core::show_run(
+        &state.workspace,
+        core::ShowRunRequest { run_id },
+    ))
+}
+
+async fn list_traces_handler(
+    State(state): State<ApiState>,
+    AxumPath(run_id): AxumPath<String>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let request = list_traces_request(run_id, raw_query.as_deref());
+    operation_response(request.and_then(|request| core::list_traces(&state.workspace, request)))
+}
+
+async fn queue_stats_handler(State(state): State<ApiState>) -> Response {
+    operation_response(core::queue_stats(&state.workspace))
+}
+
+async fn enqueue_run_handler(State(state): State<ApiState>, body: Body) -> Response {
+    let body = match parse_json_body::<EnqueueRunBody>(body).await {
+        Ok(body) => body,
+        Err(err) => return operation_error_response(err),
+    };
+    operation_response(core::enqueue_run(
+        &state.workspace,
+        core::EnqueueRunRequest {
+            script: body.script,
+            args: body.args,
+            run_id: body.run_id,
+            actor: body.actor,
+            reason: body.reason,
+            priority: body.priority,
+            timeout_ms: body.timeout_ms,
+            parent_run_id: body.parent_run_id,
+            cron_schedule_id: body.cron_schedule_id,
+        },
+    ))
+}
+
+async fn cancel_run_handler(
+    State(state): State<ApiState>,
+    AxumPath(run_id): AxumPath<String>,
+    body: Body,
+) -> Response {
+    let body = match parse_json_body::<RunReasonBody>(body).await {
+        Ok(body) => body,
+        Err(err) => return operation_error_response(err),
+    };
+    operation_response(core::cancel_run(
+        &state.workspace,
+        core::CancelRunRequest {
+            run_id,
+            reason: body.reason,
+        },
+    ))
+}
+
+async fn dead_letter_run_handler(
+    State(state): State<ApiState>,
+    AxumPath(run_id): AxumPath<String>,
+    body: Body,
+) -> Response {
+    let body = match parse_json_body::<RunReasonBody>(body).await {
+        Ok(body) => body,
+        Err(err) => return operation_error_response(err),
+    };
+    operation_response(core::dead_letter_run(
+        &state.workspace,
+        core::DeadLetterRunRequest {
+            run_id,
+            reason: body.reason,
+        },
+    ))
+}
+
+async fn list_batteries_handler(State(state): State<ApiState>) -> Response {
+    operation_response(battery_ops::list_batteries(&state.workspace))
+}
+
+async fn add_battery_handler(State(state): State<ApiState>, body: Body) -> Response {
+    let body = match parse_json_body::<AddBatteryBody>(body).await {
+        Ok(body) => body,
+        Err(err) => return operation_error_response(err),
+    };
+    if !body
+        .git_url
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("https://")
+    {
+        return operation_error_response(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            "HTTP API battery registration only accepts https git URLs",
+        ));
+    }
+    operation_response(battery_ops::add_battery(
+        &state.workspace,
+        battery_ops::AddBatteryRequest {
+            name: body.name,
+            git_url: body.git_url,
+            requested_ref: body.requested_ref,
+        },
+    ))
+}
+
+async fn sync_battery_handler(
+    State(state): State<ApiState>,
+    AxumPath(battery_id): AxumPath<String>,
+) -> Response {
+    let request = require_https_battery_source(&state.workspace, &battery_id)
+        .map(|_| battery_ops::SyncBatteryRequest { name: battery_id });
+    operation_response(
+        request.and_then(|request| battery_ops::sync_battery_https_only(&state.workspace, request)),
+    )
+}
+
+async fn inspect_battery_handler(
+    State(state): State<ApiState>,
+    AxumPath(battery_id): AxumPath<String>,
+) -> Response {
+    let request = require_https_battery_source(&state.workspace, &battery_id)
+        .map(|_| battery_ops::InspectBatteryRequest { name: battery_id });
+    operation_response(
+        request.and_then(|request| battery_ops::inspect_battery(&state.workspace, request)),
+    )
+}
+
+async fn list_battery_scripts_handler(
+    State(state): State<ApiState>,
+    AxumPath(battery_id): AxumPath<String>,
+) -> Response {
+    let request = require_https_battery_source(&state.workspace, &battery_id)
+        .map(|_| battery_ops::InspectBatteryRequest { name: battery_id });
+    operation_response(
+        request.and_then(|request| battery_ops::list_battery_scripts(&state.workspace, request)),
+    )
+}
+
+async fn install_battery_script_handler(
+    State(state): State<ApiState>,
+    AxumPath((battery_id, script_id)): AxumPath<(String, String)>,
+    body: Body,
+) -> Response {
+    let body = match parse_json_body::<InstallBatteryScriptBody>(body).await {
+        Ok(body) => body,
+        Err(err) => return operation_error_response(err),
+    };
+    let request = require_https_battery_source(&state.workspace, &battery_id).map(|_| {
+        battery_ops::InstallBatteryScriptRequest {
+            battery_name: battery_id,
+            script_id,
+            force: body.force,
+        }
+    });
+    operation_response(
+        request.and_then(|request| battery_ops::install_battery_script(&state.workspace, request)),
+    )
+}
+
+async fn remove_battery_handler(
+    State(state): State<ApiState>,
+    AxumPath(battery_id): AxumPath<String>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let request = query_pairs(raw_query.as_deref()).and_then(|pairs| {
+        query_bool(&pairs, "remove_cache").map(|remove_cache| battery_ops::RemoveBatteryRequest {
+            name: battery_id,
+            remove_cache: remove_cache.unwrap_or(false),
+        })
+    });
+    operation_response(
+        request.and_then(|request| battery_ops::remove_battery(&state.workspace, request)),
+    )
+}
+
+async fn protected_not_found() -> impl IntoResponse {
+    error_response(StatusCode::NOT_FOUND, "not_found", "endpoint not found")
+}
+
+async fn require_bearer(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if request.uri().path() == "/v1/health" {
+        return next.run(request).await;
+    }
+
+    match headers
+        .get(header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+    {
+        Some(value) if valid_authorization(value, &state.token_digest) => next.run(request).await,
+        _ => error_response(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "bearer token required",
+        ),
+    }
+}
+
+fn valid_authorization(value: &str, token_digest: &[u8; 32]) -> bool {
+    value
+        .strip_prefix("Bearer ")
+        .is_some_and(|candidate| token_digest_for(candidate).ct_eq(token_digest).into())
+}
+
+fn token_digest_for(token: &str) -> [u8; 32] {
+    Sha256::digest(token.as_bytes()).into()
+}
+
+async fn parse_json_body<T: for<'de> Deserialize<'de>>(body: Body) -> OperationResult<T> {
+    let bytes = to_bytes(body, BODY_LIMIT_BYTES).await.map_err(|err| {
+        let message = err.to_string();
+        if message.contains("length limit") {
+            OperationError::new(
+                OperationErrorCode::PayloadTooLarge,
+                "request body is too large",
+            )
+        } else {
+            OperationError::new(
+                OperationErrorCode::InvalidInput,
+                format!("invalid request body: {message}"),
+            )
+        }
+    })?;
+    serde_json::from_slice(&bytes).map_err(|err| {
+        OperationError::new(
+            OperationErrorCode::InvalidInput,
+            format!("invalid JSON request body: {err}"),
+        )
+    })
+}
+
+fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    (status, Json(json::err_envelope(code, message))).into_response()
+}
+
+fn operation_response<T: Serialize>(result: OperationResult<T>) -> Response {
+    match result {
+        Ok(data) => (StatusCode::OK, Json(json::ok_envelope(data))).into_response(),
+        Err(err) => operation_error_response(err),
+    }
+}
+
+fn operation_error_response(err: OperationError) -> Response {
+    let status = match err.code {
+        OperationErrorCode::InvalidInput
+        | OperationErrorCode::UnsafePath
+        | OperationErrorCode::ManifestInvalid => StatusCode::BAD_REQUEST,
+        OperationErrorCode::NotFound => StatusCode::NOT_FOUND,
+        OperationErrorCode::AlreadyExists
+        | OperationErrorCode::Conflict
+        | OperationErrorCode::NotSynced => StatusCode::CONFLICT,
+        OperationErrorCode::UnsupportedScript => StatusCode::NOT_IMPLEMENTED,
+        OperationErrorCode::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+        OperationErrorCode::GitFailed
+        | OperationErrorCode::IoFailed
+        | OperationErrorCode::RegistryInvalid => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    error_response(status, err.code.as_str(), &err.message)
+}
+
+fn require_https_battery_source(workspace: &Workspace, battery_id: &str) -> OperationResult<()> {
+    let battery = battery_ops::list_batteries(workspace)?
+        .into_iter()
+        .find(|battery| battery.name == battery_id)
+        .ok_or_else(|| {
+            OperationError::new(
+                OperationErrorCode::NotFound,
+                format!("battery '{battery_id}' was not found"),
+            )
+        })?;
+    if battery
+        .git_url
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("https://")
+    {
+        Ok(())
+    } else {
+        Err(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            "HTTP API can only operate on Batteries registered with https git URLs",
+        ))
+    }
+}
+
+fn list_runs_request(raw_query: Option<&str>) -> OperationResult<core::ListRunsRequest> {
+    let pairs = query_pairs(raw_query)?;
+    Ok(core::ListRunsRequest {
+        script: query_value(&pairs, "script"),
+        actor: query_value(&pairs, "actor"),
+        since_ms: query_i64(&pairs, "since_ms")?,
+        until_ms: query_i64(&pairs, "until_ms")?,
+        success: query_bool(&pairs, "success")?,
+        limit: query_i64(&pairs, "limit")?,
+        states: query_values(&pairs, "state"),
+        state_set: query_value(&pairs, "state_set"),
+    })
+}
+
+fn list_traces_request(
+    run_id: String,
+    raw_query: Option<&str>,
+) -> OperationResult<core::ListTracesRequest> {
+    let pairs = query_pairs(raw_query)?;
+    Ok(core::ListTracesRequest {
+        run_id,
+        level: query_value(&pairs, "level"),
+        since_sequence: query_i64(&pairs, "since_sequence")?,
+    })
+}
+
+fn query_pairs(raw_query: Option<&str>) -> OperationResult<Vec<(String, String)>> {
+    match raw_query {
+        Some(query) => serde_urlencoded::from_str(query).map_err(|err| {
+            OperationError::new(
+                OperationErrorCode::InvalidInput,
+                format!("invalid query string: {err}"),
+            )
+        }),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn query_value(pairs: &[(String, String)], key: &str) -> Option<String> {
+    query_values(pairs, key).into_iter().next()
+}
+
+fn query_values(pairs: &[(String, String)], key: &str) -> Vec<String> {
+    pairs
+        .iter()
+        .filter(|(name, _)| *name == key)
+        .map(|(_, value)| value.clone())
+        .collect()
+}
+
+fn query_i64(pairs: &[(String, String)], key: &str) -> OperationResult<Option<i64>> {
+    query_value(pairs, key)
+        .map(|value| {
+            value.parse::<i64>().map_err(|_| {
+                OperationError::new(
+                    OperationErrorCode::InvalidInput,
+                    format!("invalid integer query parameter: {key}"),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn query_bool(pairs: &[(String, String)], key: &str) -> OperationResult<Option<bool>> {
+    query_value(pairs, key)
+        .map(|value| {
+            value.parse::<bool>().map_err(|_| {
+                OperationError::new(
+                    OperationErrorCode::InvalidInput,
+                    format!("invalid boolean query parameter: {key}"),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn token_from_env() -> Result<String, ApiConfigError> {
+    let token = env::var("OMAKURE_API_TOKEN").map_err(|_| ApiConfigError::MissingToken)?;
+    validate_token(&token)?;
+    Ok(token.trim().to_string())
+}
+
+fn validate_token(token: &str) -> Result<(), ApiConfigError> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return Err(ApiConfigError::MissingToken);
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let known_defaults = [
+        "changeme",
+        "change-me",
+        "default",
+        "password",
+        "secret",
+        "token",
+        "omakure",
+    ];
+    if trimmed.len() < MIN_TOKEN_LEN || known_defaults.contains(&lower.as_str()) {
+        return Err(ApiConfigError::InvalidToken);
+    }
+
+    Ok(())
+}
+
+fn validate_bind(addr: SocketAddr, allow_non_loopback: bool) -> Result<(), ApiConfigError> {
+    if allow_non_loopback || addr.ip().is_loopback() {
+        return Ok(());
+    }
+
+    Err(ApiConfigError::NonLoopbackBind(addr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_meta;
+    use crate::runs::{self, EnqueueOptions, RunCompletion};
+    use axum::body::to_bytes;
+    use axum::http::Method;
+    use std::process::Command;
+    use tempfile::TempDir;
+    use tower::ServiceExt;
+
+    const TOKEN: &str = "0123456789abcdef0123456789abcdef";
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        let body = to_bytes(response.into_body(), BODY_LIMIT_BYTES)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    fn workspace_in(dir: &TempDir) -> Workspace {
+        let workspace = Workspace::new(dir.path().to_path_buf());
+        workspace.ensure_layout().unwrap();
+        workspace
+    }
+
+    fn write_script(root: &std::path::Path, name: &str) {
+        if let Some(parent) = root.join(name).parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            root.join(name),
+            format!(
+                "#!/usr/bin/env bash\n# OMAKURE_SCHEMA_START\n# {{\"Name\":\"{name}\",\"Description\":\"test script\",\"Tags\":[\"ops\"],\"Fields\":[]}}\n# OMAKURE_SCHEMA_END\necho ok\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn authed_request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn authed_json_request(uri: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    fn authed_delete_request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .method(Method::DELETE)
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn run_git(args: &[&str], cwd: &std::path::Path) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn invalid_manifest_repo() -> TempDir {
+        let repo = TempDir::new().unwrap();
+        run_git(&["init", "-b", "main"], repo.path());
+        std::fs::write(repo.path().join("omakure-battery.toml"), "not = [valid").unwrap();
+        run_git(&["add", "."], repo.path());
+        run_git(
+            &[
+                "-c",
+                "user.email=test@example.invalid",
+                "-c",
+                "user.name=Test User",
+                "commit",
+                "-m",
+                "invalid manifest",
+            ],
+            repo.path(),
+        );
+        repo
+    }
+
+    fn register_invalid_https_battery_cache(workspace: &Workspace, name: &str) {
+        let paths = battery_ops::BatteryPaths::for_workspace(workspace);
+        let cache = paths.cache_path_for(name);
+        std::fs::create_dir_all(&cache).unwrap();
+        run_git(&["init", "-b", "main"], &cache);
+        std::fs::write(cache.join("omakure-battery.toml"), "not = [valid").unwrap();
+        run_git(&["add", "."], &cache);
+        run_git(
+            &[
+                "-c",
+                "user.email=test@example.invalid",
+                "-c",
+                "user.name=Test User",
+                "commit",
+                "-m",
+                "invalid manifest",
+            ],
+            &cache,
+        );
+        let head = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&cache)
+            .output()
+            .unwrap();
+        assert!(head.status.success());
+        let registry = battery_ops::BatteryRegistry {
+            version: battery_ops::REGISTRY_VERSION,
+            batteries: vec![battery_ops::BatterySummary {
+                name: name.to_string(),
+                git_url: format!("https://example.invalid/{name}.git"),
+                requested_ref: "main".into(),
+                resolved_commit: Some(String::from_utf8_lossy(&head.stdout).trim().to_string()),
+                cache_path: paths
+                    .cache_path_for(name)
+                    .strip_prefix(workspace.root())
+                    .unwrap()
+                    .to_path_buf(),
+                last_synced_at: Some("2026-07-07T00:00:00Z".into()),
+            }],
+        };
+        std::fs::write(
+            &paths.registry_path,
+            serde_json::to_string_pretty(&registry).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn bind_guard_allows_loopback_by_default() {
+        let addr: SocketAddr = "127.0.0.1:7878".parse().unwrap();
+        assert!(validate_bind(addr, false).is_ok());
+    }
+
+    #[test]
+    fn bind_guard_rejects_non_loopback_without_opt_in() {
+        let addr: SocketAddr = "0.0.0.0:7878".parse().unwrap();
+        assert_eq!(
+            validate_bind(addr, false),
+            Err(ApiConfigError::NonLoopbackBind(addr))
+        );
+    }
+
+    #[test]
+    fn bind_guard_allows_non_loopback_with_opt_in() {
+        let addr: SocketAddr = "0.0.0.0:7878".parse().unwrap();
+        assert!(validate_bind(addr, true).is_ok());
+    }
+
+    #[test]
+    fn token_validation_rejects_empty_short_and_defaults() {
+        assert_eq!(validate_token(""), Err(ApiConfigError::MissingToken));
+        assert_eq!(validate_token("short"), Err(ApiConfigError::InvalidToken));
+        assert_eq!(
+            validate_token("changeme"),
+            Err(ApiConfigError::InvalidToken)
+        );
+    }
+
+    #[test]
+    fn token_validation_accepts_long_token() {
+        assert!(validate_token(TOKEN).is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_works_without_token() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/v1/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["data"]["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn protected_route_rejects_missing_token() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/v1/scripts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["error"]["code"], "unauthorized");
+    }
+
+    #[tokio::test]
+    async fn protected_route_rejects_invalid_token() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/v1/scripts")
+                    .header(header::AUTHORIZATION, "Bearer wrong-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn protected_route_accepts_valid_token() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/unknown"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn workspace_endpoint_returns_summary() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/workspace"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["data"]["version"], app_meta::APP_VERSION);
+    }
+
+    #[tokio::test]
+    async fn scripts_and_schema_endpoints_return_operation_data() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+
+        let app = router(TOKEN.to_string(), workspace);
+        let list = app
+            .clone()
+            .oneshot(authed_request("/v1/scripts?tag=ops"))
+            .await
+            .unwrap();
+        assert_eq!(list.status(), StatusCode::OK);
+        let list_body = response_json(list).await;
+        assert_eq!(list_body["data"][0]["relative_path"], "job.sh");
+
+        let show = app
+            .clone()
+            .oneshot(authed_request("/v1/scripts/job.sh"))
+            .await
+            .unwrap();
+        assert_eq!(show.status(), StatusCode::OK);
+        let show_body = response_json(show).await;
+        assert_eq!(show_body["data"]["schema"]["name"], "job.sh");
+
+        let schema = app
+            .oneshot(authed_request("/v1/scripts/job.sh/schema"))
+            .await
+            .unwrap();
+        assert_eq!(schema.status(), StatusCode::OK);
+        let schema_body = response_json(schema).await;
+        assert_eq!(schema_body["data"]["tags"][0], "ops");
+    }
+
+    #[tokio::test]
+    async fn script_routes_support_nested_paths() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "tools/job.sh");
+
+        let app = router(TOKEN.to_string(), workspace);
+        let show = app
+            .clone()
+            .oneshot(authed_request("/v1/scripts/tools/job.sh"))
+            .await
+            .unwrap();
+        assert_eq!(show.status(), StatusCode::OK);
+        let show_body = response_json(show).await;
+        assert_eq!(show_body["data"]["relative_path"], "tools/job.sh");
+
+        let schema = app
+            .oneshot(authed_request("/v1/scripts/tools/job.sh/schema"))
+            .await
+            .unwrap();
+        assert_eq!(schema.status(), StatusCode::OK);
+        let schema_body = response_json(schema).await;
+        assert_eq!(schema_body["data"]["name"], "tools/job.sh");
+    }
+
+    #[tokio::test]
+    async fn scripts_query_percent_decodes_values() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/scripts?tag=ops%20team"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["data"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn scripts_endpoint_maps_missing_script_to_404() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/scripts/missing.sh"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn runs_and_queue_stats_endpoints_return_operation_data() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+        let conn = runs::open(&workspace).unwrap();
+        runs::enqueue(
+            &conn,
+            workspace
+                .scripts_root()
+                .join("job.sh")
+                .to_string_lossy()
+                .as_ref(),
+            &[],
+            EnqueueOptions {
+                run_id: Some("rid-http".into()),
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+                script_name: None,
+                omakure_version: app_meta::APP_VERSION.to_string(),
+                trigger: runs::RunTrigger::Manual,
+            },
+        )
+        .unwrap();
+
+        let app = router(TOKEN.to_string(), workspace);
+        let list = app
+            .clone()
+            .oneshot(authed_request("/v1/runs?state_set=all"))
+            .await
+            .unwrap();
+        assert_eq!(list.status(), StatusCode::OK);
+        let list_body = response_json(list).await;
+        assert_eq!(list_body["data"][0]["run_id"], "rid-http");
+
+        let show = app
+            .clone()
+            .oneshot(authed_request("/v1/runs/rid-http"))
+            .await
+            .unwrap();
+        assert_eq!(show.status(), StatusCode::OK);
+        let show_body = response_json(show).await;
+        assert_eq!(show_body["data"]["actor"], "agent");
+
+        let traces = app
+            .clone()
+            .oneshot(authed_request("/v1/runs/rid-http/traces"))
+            .await
+            .unwrap();
+        assert_eq!(traces.status(), StatusCode::OK);
+
+        let stats = app
+            .oneshot(authed_request("/v1/queue/stats"))
+            .await
+            .unwrap();
+        assert_eq!(stats.status(), StatusCode::OK);
+        let stats_body = response_json(stats).await;
+        assert_eq!(stats_body["data"]["total"], 1);
+    }
+
+    #[tokio::test]
+    async fn runs_endpoint_maps_invalid_query_to_400() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/runs?state=bad"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn enqueue_run_requires_auth() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/runs")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"script":"job.sh"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "unauthorized");
+    }
+
+    #[tokio::test]
+    async fn enqueue_run_returns_queued_run() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request(
+                "/v1/runs",
+                r#"{"script":"job","args":["--x"],"run_id":"rid-post","actor":"agent","reason":"api","priority":7,"timeout_ms":1000}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["data"]["run_id"], "rid-post");
+        assert_eq!(body["data"]["state"], "queued");
+        assert_eq!(body["data"]["actor"], "agent");
+        assert_eq!(body["data"]["priority"], 7);
+    }
+
+    #[tokio::test]
+    async fn enqueue_run_maps_invalid_script_to_404() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request(
+                "/v1/runs",
+                r#"{"script":"missing.sh"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn enqueue_run_rejects_outside_workspace_script() {
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(outside.path(), "outside.sh");
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request(
+                "/v1/runs",
+                &format!(
+                    r#"{{"script":"{}"}}"#,
+                    outside.path().join("outside.sh").display()
+                ),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "unsafe_path");
+    }
+
+    #[tokio::test]
+    async fn malformed_json_returns_envelope() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request("/v1/runs", r#"{"#))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["error"]["code"], "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn oversized_json_returns_envelope() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let body = format!(r#"{{"script":"{}"}}"#, "x".repeat(BODY_LIMIT_BYTES + 1));
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request("/v1/runs", &body))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "payload_too_large");
+    }
+
+    #[tokio::test]
+    async fn cancel_run_success_and_missing_run() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+        let conn = runs::open(&workspace).unwrap();
+        runs::enqueue(
+            &conn,
+            workspace
+                .scripts_root()
+                .join("job.sh")
+                .to_string_lossy()
+                .as_ref(),
+            &[],
+            EnqueueOptions {
+                run_id: Some("rid-cancel".into()),
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+                script_name: None,
+                omakure_version: app_meta::APP_VERSION.to_string(),
+                trigger: runs::RunTrigger::Manual,
+            },
+        )
+        .unwrap();
+
+        let app = router(TOKEN.to_string(), workspace);
+        let cancelled = app
+            .clone()
+            .oneshot(authed_json_request(
+                "/v1/runs/rid-cancel/cancel",
+                r#"{"reason":"stop"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(cancelled.status(), StatusCode::OK);
+        let cancelled_body = response_json(cancelled).await;
+        assert_eq!(cancelled_body["data"]["state"], "cancelled");
+
+        let missing = app
+            .oneshot(authed_json_request("/v1/runs/missing/cancel", r#"{}"#))
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cancel_run_maps_invalid_transition_to_conflict() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+        let conn = runs::open(&workspace).unwrap();
+        let row = runs::start_inline(
+            &conn,
+            workspace
+                .scripts_root()
+                .join("job.sh")
+                .to_string_lossy()
+                .as_ref(),
+            &[],
+            "worker:test",
+            EnqueueOptions {
+                run_id: Some("rid-done".into()),
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+                script_name: None,
+                omakure_version: app_meta::APP_VERSION.to_string(),
+                trigger: runs::RunTrigger::Manual,
+            },
+        )
+        .unwrap();
+        runs::complete(
+            &conn,
+            &row.run_id,
+            RunCompletion {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(0),
+                success: true,
+                error: None,
+            },
+        )
+        .unwrap();
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request("/v1/runs/rid-done/cancel", r#"{}"#))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "conflict");
+    }
+
+    #[tokio::test]
+    async fn dead_letter_run_success_and_invalid_transition() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        write_script(workspace.scripts_root(), "job.sh");
+        let conn = runs::open(&workspace).unwrap();
+        let failed = runs::start_inline(
+            &conn,
+            workspace
+                .scripts_root()
+                .join("job.sh")
+                .to_string_lossy()
+                .as_ref(),
+            &[],
+            "worker:test",
+            EnqueueOptions {
+                run_id: Some("rid-failed".into()),
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+                script_name: None,
+                omakure_version: app_meta::APP_VERSION.to_string(),
+                trigger: runs::RunTrigger::Manual,
+            },
+        )
+        .unwrap();
+        runs::fail(
+            &conn,
+            &failed.run_id,
+            RunCompletion {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(1),
+                success: false,
+                error: Some("boom".into()),
+            },
+        )
+        .unwrap();
+        runs::enqueue(
+            &conn,
+            workspace
+                .scripts_root()
+                .join("job.sh")
+                .to_string_lossy()
+                .as_ref(),
+            &[],
+            EnqueueOptions {
+                run_id: Some("rid-queued".into()),
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+                script_name: None,
+                omakure_version: app_meta::APP_VERSION.to_string(),
+                trigger: runs::RunTrigger::Manual,
+            },
+        )
+        .unwrap();
+
+        let app = router(TOKEN.to_string(), workspace);
+        let promoted = app
+            .clone()
+            .oneshot(authed_json_request(
+                "/v1/runs/rid-failed/dead-letter",
+                r#"{"reason":"triaged"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(promoted.status(), StatusCode::OK);
+        let promoted_body = response_json(promoted).await;
+        assert_eq!(promoted_body["data"]["state"], "dead_letter");
+
+        let invalid = app
+            .oneshot(authed_json_request(
+                "/v1/runs/rid-queued/dead-letter",
+                r#"{}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::CONFLICT);
+        let invalid_body = response_json(invalid).await;
+        assert_eq!(invalid_body["error"]["code"], "conflict");
+    }
+
+    #[tokio::test]
+    async fn battery_endpoints_require_auth() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/v1/batteries")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn battery_add_and_list_use_operations() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let app = router(TOKEN.to_string(), workspace);
+        let add = app
+            .clone()
+            .oneshot(authed_json_request(
+                "/v1/batteries",
+                r#"{"name":"azure","git_url":"https://example.invalid/azure.git","requested_ref":"stable"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(add.status(), StatusCode::OK);
+        let add_body = response_json(add).await;
+        assert_eq!(add_body["data"]["name"], "azure");
+        assert_eq!(add_body["data"]["requested_ref"], "stable");
+
+        let list = app.oneshot(authed_request("/v1/batteries")).await.unwrap();
+        assert_eq!(list.status(), StatusCode::OK);
+        let list_body = response_json(list).await;
+        assert_eq!(list_body["data"][0]["name"], "azure");
+    }
+
+    #[tokio::test]
+    async fn battery_add_rejects_plaintext_http_git_url() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request(
+                "/v1/batteries",
+                r#"{"name":"plain","git_url":"http://example.invalid/plain.git"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn battery_add_rejects_local_git_url() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request(
+                "/v1/batteries",
+                r#"{"name":"local","git_url":"/tmp/local-battery.git"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn battery_sync_invalid_manifest_maps_to_400() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        register_invalid_https_battery_cache(&workspace, "bad");
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/batteries/bad"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "manifest_invalid");
+    }
+
+    #[tokio::test]
+    async fn battery_http_operations_reject_existing_non_https_sources() {
+        let repo = invalid_manifest_repo();
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        battery_ops::add_battery(
+            &workspace,
+            battery_ops::AddBatteryRequest {
+                name: "local".into(),
+                git_url: repo.path().display().to_string(),
+                requested_ref: "main".into(),
+            },
+        )
+        .unwrap();
+
+        let app = router(TOKEN.to_string(), workspace);
+        for request in [
+            authed_json_request("/v1/batteries/local/sync", r#"{}"#),
+            authed_request("/v1/batteries/local"),
+            authed_request("/v1/batteries/local/scripts"),
+            authed_json_request("/v1/batteries/local/scripts/list/install", r#"{}"#),
+        ] {
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = response_json(response).await;
+            assert_eq!(body["error"]["code"], "invalid_input");
+        }
+    }
+
+    #[tokio::test]
+    async fn battery_missing_and_unsynced_errors_are_stable() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        battery_ops::add_battery(
+            &workspace,
+            battery_ops::AddBatteryRequest {
+                name: "azure".into(),
+                git_url: "https://example.invalid/azure.git".into(),
+                requested_ref: "main".into(),
+            },
+        )
+        .unwrap();
+
+        let app = router(TOKEN.to_string(), workspace);
+        let missing = app
+            .clone()
+            .oneshot(authed_request("/v1/batteries/missing"))
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+        let missing_body = response_json(missing).await;
+        assert_eq!(missing_body["error"]["code"], "not_found");
+
+        let unsynced = app
+            .clone()
+            .oneshot(authed_request("/v1/batteries/azure/scripts"))
+            .await
+            .unwrap();
+        assert_eq!(unsynced.status(), StatusCode::CONFLICT);
+        let unsynced_body = response_json(unsynced).await;
+        assert_eq!(unsynced_body["error"]["code"], "not_synced");
+
+        let install = app
+            .oneshot(authed_json_request(
+                "/v1/batteries/azure/scripts/list/install",
+                r#"{}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(install.status(), StatusCode::CONFLICT);
+        let install_body = response_json(install).await;
+        assert_eq!(install_body["error"]["code"], "not_synced");
+    }
+
+    #[tokio::test]
+    async fn battery_sync_missing_maps_to_404() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_json_request("/v1/batteries/missing/sync", r#"{}"#))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn battery_remove_supports_cache_flag() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        battery_ops::add_battery(
+            &workspace,
+            battery_ops::AddBatteryRequest {
+                name: "keep".into(),
+                git_url: "https://example.invalid/keep.git".into(),
+                requested_ref: "main".into(),
+            },
+        )
+        .unwrap();
+        battery_ops::add_battery(
+            &workspace,
+            battery_ops::AddBatteryRequest {
+                name: "drop".into(),
+                git_url: "https://example.invalid/drop.git".into(),
+                requested_ref: "main".into(),
+            },
+        )
+        .unwrap();
+        let paths = battery_ops::BatteryPaths::for_workspace(&workspace);
+        std::fs::create_dir_all(paths.cache_path_for("drop")).unwrap();
+
+        let app = router(TOKEN.to_string(), workspace);
+        let keep = app
+            .clone()
+            .oneshot(authed_delete_request("/v1/batteries/keep"))
+            .await
+            .unwrap();
+        assert_eq!(keep.status(), StatusCode::OK);
+        let keep_body = response_json(keep).await;
+        assert_eq!(keep_body["data"]["cache_removed"], false);
+
+        let drop = app
+            .oneshot(authed_delete_request(
+                "/v1/batteries/drop?remove_cache=true",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(drop.status(), StatusCode::OK);
+        let drop_body = response_json(drop).await;
+        assert_eq!(drop_body["data"]["cache_removed"], true);
+    }
+}

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -1129,6 +1129,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_endpoint_rejects_excessive_tags() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let app = router(TOKEN.to_string(), workspace);
+
+        let too_many_tags = (0..=MAX_SEARCH_TAGS)
+            .map(|idx| format!("tag=t{idx}"))
+            .collect::<Vec<_>>()
+            .join("&");
+        let too_many = app
+            .clone()
+            .oneshot(authed_request(&format!(
+                "/v1/search?q=deploy&{too_many_tags}"
+            )))
+            .await
+            .unwrap();
+        assert_eq!(too_many.status(), StatusCode::BAD_REQUEST);
+
+        let too_long_tag = "x".repeat(MAX_SEARCH_TAG_LEN + 1);
+        let long = app
+            .oneshot(authed_request(&format!(
+                "/v1/search?q=deploy&tag={too_long_tag}"
+            )))
+            .await
+            .unwrap();
+        assert_eq!(long.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn script_routes_support_nested_paths() {
         let dir = TempDir::new().unwrap();
         let workspace = workspace_in(&dir);
@@ -1220,6 +1249,43 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_json(response).await;
         assert_eq!(body["error"]["code"], "unsafe_path");
+    }
+
+    #[tokio::test]
+    async fn tree_and_content_endpoints_reject_metadata_paths() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let app = router(TOKEN.to_string(), workspace);
+
+        for uri in [
+            "/v1/tree/.omakure",
+            "/v1/tree/.history",
+            "/v1/tree/.git",
+            "/v1/scripts/.omakure/secret.sh/content",
+            "/v1/scripts/.history/secret.sh/content",
+            "/v1/scripts/.git/secret.sh/content",
+        ] {
+            let response = app.clone().oneshot(authed_request(uri)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = response_json(response).await;
+            assert_eq!(body["error"]["code"], "unsafe_path");
+        }
+    }
+
+    #[tokio::test]
+    async fn content_endpoint_error_hides_local_paths() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        let root = workspace.root().display().to_string();
+
+        let response = router(TOKEN.to_string(), workspace)
+            .oneshot(authed_request("/v1/scripts/../secret.sh/content"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert!(!body.to_string().contains(&root));
     }
 
     #[tokio::test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -80,6 +80,15 @@ pub enum Commands {
     /// Manage reusable Battery automation repositories
     Battery(BatteryArgs),
 
+    /// Run the internal HTTP management API
+    ///
+    /// Starts a loopback-only HTTP API by default at `127.0.0.1:7878`.
+    /// All endpoints except `/v1/health` require `Authorization: Bearer <token>`
+    /// using `OMAKURE_API_TOKEN`. Binding to non-loopback addresses requires
+    /// `--allow-non-loopback` and should only be used behind trusted network
+    /// controls.
+    Api(ApiArgs),
+
     /// Append a structured trace event from inside a running script
     Trace(TraceArgs),
 
@@ -191,6 +200,17 @@ pub struct DescribeArgs {
     /// Script name or path
     #[arg(value_name = "SCRIPT")]
     pub script: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ApiArgs {
+    /// Address to bind the HTTP API server to
+    #[arg(long, default_value = "127.0.0.1:7878")]
+    pub bind: std::net::SocketAddr,
+
+    /// Explicitly allow binding to non-loopback addresses
+    #[arg(long)]
+    pub allow_non_loopback: bool,
 }
 
 #[derive(Args, Debug)]
@@ -596,6 +616,7 @@ pub struct QueueAddArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
     use clap::Parser;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
@@ -730,6 +751,42 @@ mod tests {
             },
             _ => panic!("expected Battery"),
         }
+    }
+
+    #[test]
+    fn test_parse_api_defaults() {
+        let cli = parse(&["api"]).unwrap();
+        match cli.command.unwrap() {
+            Commands::Api(args) => {
+                assert_eq!(args.bind.to_string(), "127.0.0.1:7878");
+                assert!(!args.allow_non_loopback);
+            }
+            _ => panic!("expected Api"),
+        }
+    }
+
+    #[test]
+    fn test_parse_api_bind_flags() {
+        let cli = parse(&["api", "--bind", "0.0.0.0:7878", "--allow-non-loopback"]).unwrap();
+        match cli.command.unwrap() {
+            Commands::Api(args) => {
+                assert_eq!(args.bind.to_string(), "0.0.0.0:7878");
+                assert!(args.allow_non_loopback);
+            }
+            _ => panic!("expected Api"),
+        }
+    }
+
+    #[test]
+    fn test_api_help_surface_exists() {
+        let command = Cli::command();
+        let api = command
+            .find_subcommand("api")
+            .expect("api subcommand should be registered");
+        assert!(api.get_arguments().any(|arg| arg.get_id() == "bind"));
+        assert!(api
+            .get_arguments()
+            .any(|arg| arg.get_id() == "allow_non_loopback"));
     }
 
     #[test]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,190 +1,50 @@
-use crate::adapters::environments::{
-    is_sensitive_key, resolve_active_env, should_mask_env_value, FsEnvironmentRepository,
-    MASKED_ENV_VALUE,
-};
-use crate::app_meta;
 use crate::cli::json;
-use crate::ports::EnvironmentRepository;
-use crate::runtime::{python_program, resolve_interpreter};
+use crate::operations::config::{self, ConfigSummary, EnvVarView, InterpreterView};
 use crate::workspace::Workspace;
-use serde::Serialize;
 use std::collections::BTreeMap;
-use std::env;
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-/// JSON shape for `omakure config --json`.
-#[derive(Debug, Serialize)]
-pub struct ConfigPayload {
-    pub version: String,
-    pub binary: String,
-    pub workspace_root: String,
-    pub scripts_root: String,
-    pub omakure_dir: String,
-    pub history_dir: String,
-    pub workspace_config: String,
-    pub envs_dir: String,
-    pub envs_active_path: String,
-    pub active_env: Option<String>,
-    pub bootstrap_mode: String,
-    pub env_overrides: BTreeMap<String, String>,
-    /// Resolved active-env `KEY=value` pairs, with sensitive values masked.
-    /// Order and key case mirror the injected env (see `resolve_active_env`).
-    pub active_env_keys: Vec<EnvVarView>,
-    /// The interpreter omakure would spawn for `.py` scripts, resolved
-    /// against the active env's `PATH` (falls back to name-based lookup).
-    pub interpreter: InterpreterView,
-}
-
-/// A single resolved active-env entry. `value` is already masked for
-/// sensitive keys (see [`is_sensitive_key`]); the raw value is never surfaced.
-#[derive(Debug, Serialize)]
-pub struct EnvVarView {
-    pub key: String,
-    pub value: String,
-}
-
-/// The interpreter that would run `.py` scripts. `path` is the absolute
-/// binary resolved against the active env's `PATH`; `None` means omakure
-/// falls back to name-based resolution of `program`.
-#[derive(Debug, Serialize)]
-pub struct InterpreterView {
-    pub program: String,
-    pub path: Option<String>,
-}
+pub type ConfigPayload = ConfigSummary;
 
 pub fn run(scripts_dir: PathBuf, json_output: bool) -> Result<(), Box<dyn Error>> {
-    let exe = env::current_exe()?;
     let workspace = Workspace::new(scripts_dir);
-    let active_env = read_active_env(&workspace);
-    let (active_env_keys, interpreter) = resolve_env_diagnostics(workspace.envs_dir());
+    let payload = config::config_summary(&workspace)?;
 
     if json_output {
-        let payload = ConfigPayload {
-            version: app_meta::APP_VERSION.to_string(),
-            binary: exe.display().to_string(),
-            workspace_root: workspace.root().display().to_string(),
-            scripts_root: workspace.scripts_root().display().to_string(),
-            omakure_dir: workspace.omakure_dir().display().to_string(),
-            history_dir: workspace.history_dir().display().to_string(),
-            workspace_config: workspace.config_path().display().to_string(),
-            envs_dir: workspace.envs_dir().display().to_string(),
-            envs_active_path: workspace.envs_active_path().display().to_string(),
-            active_env,
-            // The CLI dispatch never opens the TUI, so `omakure config` is
-            // always the global "plain" mode. The TUI bootstrap label is
-            // a separate concern handled inside the TUI itself.
-            bootstrap_mode: "plain".to_string(),
-            env_overrides: collect_env_overrides(),
-            active_env_keys,
-            interpreter,
-        };
         json::print_ok(payload);
         return Ok(());
     }
 
-    println!("Version: {}", app_meta::APP_VERSION);
-    println!("Binary: {}", exe.display());
-    println!("Workspace root: {}", workspace.root().display());
-    println!("Omakure dir: {}", workspace.omakure_dir().display());
-    println!("History dir: {}", workspace.history_dir().display());
-    println!("Workspace config: {}", workspace.config_path().display());
-    println!("Environments dir: {}", workspace.envs_dir().display());
-    println!(
-        "Active environment file: {}",
-        workspace.envs_active_path().display()
-    );
-    if let Some(env) = &active_env {
-        println!("Active environment: {}", env);
-    }
-    print!("{}", render_env_diagnostics(&active_env_keys, &interpreter));
-
-    print_env_if_set("OMAKURE_SCRIPTS_DIR");
-    print_env_if_set("OMAKURE_REPO");
-    print_env_if_set("REPO");
-    print_env_if_set("VERSION");
-    print_env_if_set("OVERTURE_SCRIPTS_DIR");
-    print_env_if_set("OVERTURE_REPO");
-    print_env_if_set("CLOUD_MGMT_SCRIPTS_DIR");
-    print_env_if_set("CLOUD_MGMT_REPO");
-
+    print_human(&payload);
     Ok(())
 }
 
-fn print_env_if_set(name: &str) {
-    if let Ok(value) = env::var(name) {
-        println!("{}: {}", name, mask_env_display_value(name, value));
+fn print_human(payload: &ConfigPayload) {
+    println!("Version: {}", payload.version);
+    println!("Binary: {}", payload.binary);
+    println!("Workspace root: {}", payload.workspace_root);
+    println!("Omakure dir: {}", payload.omakure_dir);
+    println!("History dir: {}", payload.history_dir);
+    println!("Workspace config: {}", payload.workspace_config);
+    println!("Environments dir: {}", payload.envs_dir);
+    println!("Active environment file: {}", payload.envs_active_path);
+    if let Some(env) = &payload.active_env {
+        println!("Active environment: {}", env);
     }
+    print!(
+        "{}",
+        render_env_diagnostics(&payload.active_env_keys, &payload.interpreter)
+    );
+    print_env_overrides(&payload.env_overrides);
 }
 
-fn read_active_env(workspace: &Workspace) -> Option<String> {
-    let repo = FsEnvironmentRepository::new(workspace.envs_dir());
-    repo.load_environment_config().ok().and_then(|c| c.active)
-}
-
-/// Resolve the active env into masked `KEY=value` views plus the interpreter
-/// that would actually run `.py` scripts.
-///
-/// Values for sensitive keys, credential-bearing URLs, and values that match a
-/// sensitive parent-env value are masked with `****`; the raw value never
-/// leaves [`resolve_active_env`]. The interpreter
-/// path is resolved against the active env's `PATH` exactly as a real run
-/// would (see [`resolve_interpreter`]), so users can confirm *which* python
-/// omakure spawns and debug env/interpreter collisions.
-pub(crate) fn resolve_env_diagnostics(envs_dir: &Path) -> (Vec<EnvVarView>, InterpreterView) {
-    let pairs = resolve_active_env(envs_dir);
-    let sensitive_parent_values = sensitive_parent_values();
-    let program = python_program();
-    let path = resolve_interpreter(program, &pairs).map(|p| p.display().to_string());
-
-    let keys = pairs
-        .into_iter()
-        .map(|(key, value)| {
-            let value = if should_mask_resolved_env_value(&key, &value, &sensitive_parent_values) {
-                MASKED_ENV_VALUE.to_string()
-            } else {
-                value
-            };
-            EnvVarView { key, value }
-        })
-        .collect();
-
-    (
-        keys,
-        InterpreterView {
-            program: program.to_string(),
-            path,
-        },
-    )
-}
-
-fn mask_env_display_value(key: &str, value: String) -> String {
-    if should_mask_env_value(key, &value) {
-        MASKED_ENV_VALUE.to_string()
-    } else {
-        value
+fn print_env_overrides(overrides: &BTreeMap<String, String>) {
+    for name in config::env_override_names() {
+        if let Some(value) = overrides.get(name) {
+            println!("{}: {}", name, value);
+        }
     }
-}
-
-fn sensitive_parent_values() -> Vec<String> {
-    env::vars()
-        .filter_map(|(key, value)| {
-            if is_sensitive_key(&key) && !value.is_empty() {
-                Some(value)
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-fn should_mask_resolved_env_value(
-    key: &str,
-    value: &str,
-    sensitive_parent_values: &[String],
-) -> bool {
-    should_mask_env_value(key, value)
-        || (!value.is_empty() && sensitive_parent_values.iter().any(|secret| secret == value))
 }
 
 /// Render the human-readable env/interpreter diagnostics block for
@@ -220,85 +80,10 @@ fn render_env_diagnostics(keys: &[EnvVarView], interpreter: &InterpreterView) ->
     out
 }
 
-pub(crate) fn collect_env_overrides() -> BTreeMap<String, String> {
-    let names = [
-        "OMAKURE_SCRIPTS_DIR",
-        "OMAKURE_REPO",
-        "REPO",
-        "VERSION",
-        "OVERTURE_SCRIPTS_DIR",
-        "OVERTURE_REPO",
-        "CLOUD_MGMT_SCRIPTS_DIR",
-        "CLOUD_MGMT_REPO",
-    ];
-    let mut out = BTreeMap::new();
-    for name in names {
-        if let Ok(value) = env::var(name) {
-            out.insert(name.to_string(), value);
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_collect_env_overrides_only_known_names() {
-        let overrides = collect_env_overrides();
-        let known = [
-            "OMAKURE_SCRIPTS_DIR",
-            "OMAKURE_REPO",
-            "REPO",
-            "VERSION",
-            "OVERTURE_SCRIPTS_DIR",
-            "OVERTURE_REPO",
-            "CLOUD_MGMT_SCRIPTS_DIR",
-            "CLOUD_MGMT_REPO",
-        ];
-        for key in overrides.keys() {
-            assert!(known.contains(&key.as_str()), "unexpected key: {}", key);
-        }
-    }
-
-    #[test]
-    fn test_collect_env_overrides_picks_up_set_vars() {
-        env::set_var("OMAKURE_SCRIPTS_DIR", "/test/scripts");
-        let overrides = collect_env_overrides();
-        assert_eq!(
-            overrides.get("OMAKURE_SCRIPTS_DIR"),
-            Some(&"/test/scripts".to_string())
-        );
-        env::remove_var("OMAKURE_SCRIPTS_DIR");
-    }
-
-    #[test]
-    fn test_run_human_and_json_modes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let scripts = tmp.path().to_path_buf();
-        // Set one known env var so the print branch is exercised.
-        env::set_var("REPO", "owner/repo");
-        run(scripts.clone(), false).unwrap();
-        run(scripts, true).unwrap();
-        env::remove_var("REPO");
-    }
-
-    #[test]
-    fn test_print_env_if_set_does_not_panic() {
-        env::set_var("VERSION", "1.2.3");
-        print_env_if_set("VERSION");
-        env::remove_var("VERSION");
-        // Missing var hits the silent branch.
-        print_env_if_set("__omakure_no_such_env_var__");
-    }
-
-    #[test]
-    fn test_read_active_env_returns_none_for_missing() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let workspace = Workspace::new(tmp.path().to_path_buf());
-        assert!(read_active_env(&workspace).is_none());
-    }
+    use crate::app_meta;
 
     #[test]
     fn test_config_payload_serializes() {
@@ -325,84 +110,29 @@ mod tests {
         assert!(json.contains("\"version\":\"0.1.8\""));
     }
 
-    // --- Task 1757: env/interpreter surfacing in `omakure config` ---
-
-    use std::fs;
-
-    fn write_active_env(dir: &Path, conf_name: &str, contents: &str) {
-        fs::create_dir_all(dir).unwrap();
-        fs::write(dir.join(conf_name), contents).unwrap();
-        fs::write(dir.join("active"), format!("{}\n", conf_name)).unwrap();
-    }
-
     #[test]
-    fn test_resolve_env_diagnostics_masks_sensitive_values() {
+    fn test_run_human_and_json_modes() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let envs = tmp.path().join("envs");
-        write_active_env(
-            &envs,
-            "dev.conf",
-            "HOST=localhost\nAPI_KEY=supersecret123\n",
-        );
-
-        let (keys, _interp) = resolve_env_diagnostics(&envs);
-
-        // Non-sensitive value is shown plainly, order preserved.
-        assert_eq!(keys[0].key, "HOST");
-        assert_eq!(keys[0].value, "localhost");
-        // Sensitive value is masked — the raw secret must not appear.
-        assert_eq!(keys[1].key, "API_KEY");
-        assert_eq!(keys[1].value, "****");
-        assert!(keys.iter().all(|kv| kv.value != "supersecret123"));
+        let scripts = tmp.path().to_path_buf();
+        run(scripts.clone(), false).unwrap();
+        run(scripts, true).unwrap();
     }
 
     #[test]
-    fn test_resolve_env_diagnostics_masks_parent_sourced_secret_value() {
+    fn test_config_summary_returns_current_version() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let envs = tmp.path().join("envs");
-        env::set_var("AWS_SECRET_ACCESS_KEY", "parent-secret-value");
-        write_active_env(&envs, "dev.conf", "PLAIN=$AWS_SECRET_ACCESS_KEY\n");
-
-        let (keys, _interp) = resolve_env_diagnostics(&envs);
-
-        env::remove_var("AWS_SECRET_ACCESS_KEY");
-        assert_eq!(keys[0].key, "PLAIN");
-        assert_eq!(keys[0].value, "****");
+        let workspace = Workspace::new(tmp.path().to_path_buf());
+        let payload = config::config_summary(&workspace).unwrap();
+        assert_eq!(payload.version, app_meta::APP_VERSION);
+        assert!(payload.active_env.is_none());
     }
 
     #[test]
-    fn test_resolve_env_diagnostics_masks_credential_url_value() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let envs = tmp.path().join("envs");
-        write_active_env(
-            &envs,
-            "dev.conf",
-            "DATABASE_URL=postgres://user:pass@localhost/db\n",
-        );
-
-        let (keys, _interp) = resolve_env_diagnostics(&envs);
-
-        assert_eq!(keys[0].key, "DATABASE_URL");
-        assert_eq!(keys[0].value, "****");
-    }
-
-    #[test]
-    fn test_mask_env_display_value_masks_sensitive_and_credential_values() {
-        assert_eq!(
-            mask_env_display_value("MYSQL_PWD", "secret".to_string()),
-            "****"
-        );
-        assert_eq!(
-            mask_env_display_value(
-                "DATABASE_URL",
-                "postgres://user:pass@localhost/db".to_string()
-            ),
-            "****"
-        );
-        assert_eq!(
-            mask_env_display_value("VERSION", "1.2.3".to_string()),
-            "1.2.3"
-        );
+    fn test_print_env_overrides_uses_stable_order() {
+        let mut overrides = BTreeMap::new();
+        overrides.insert("VERSION".to_string(), "1.2.3".to_string());
+        overrides.insert("REPO".to_string(), "owner/repo".to_string());
+        print_env_overrides(&overrides);
     }
 
     #[test]
@@ -424,12 +154,9 @@ mod tests {
 
         let rendered = render_env_diagnostics(&keys, &interpreter);
 
-        // Keys are surfaced.
         assert!(rendered.contains("HOST = localhost"));
         assert!(rendered.contains("API_KEY = ****"));
-        // The resolved interpreter absolute path is surfaced.
         assert!(rendered.contains("Resolved python3 interpreter: /proj/.venv/bin/python3"));
-        // The raw secret never leaks (defense in depth).
         assert!(!rendered.contains("supersecret123"));
     }
 
@@ -442,29 +169,5 @@ mod tests {
         let rendered = render_env_diagnostics(&[], &interpreter);
         assert!(rendered.contains("Active env keys: (none)"));
         assert!(rendered.contains("name-based fallback"));
-    }
-
-    /// With an injected `PATH` prepending a shim `python3`, the resolved
-    /// interpreter must be the absolute shim path — proving `config` reports
-    /// which interpreter a real run would actually spawn.
-    #[cfg(unix)]
-    #[test]
-    fn test_resolve_env_diagnostics_resolves_interpreter_absolute_path() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let tmp = tempfile::TempDir::new().unwrap();
-        let bin = tmp.path().join("venv-bin");
-        fs::create_dir_all(&bin).unwrap();
-        let shim = bin.join("python3");
-        fs::write(&shim, "#!/bin/sh\necho shim\n").unwrap();
-        let mut perms = fs::metadata(&shim).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&shim, perms).unwrap();
-
-        let envs = tmp.path().join("envs");
-        write_active_env(&envs, "dev.conf", &format!("PATH={}\n", bin.display()));
-
-        let (_keys, interp) = resolve_env_diagnostics(&envs);
-        assert_eq!(interp.path.as_deref(), Some(shim.to_str().unwrap()));
     }
 }

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -1,17 +1,14 @@
 //! `omakure describe <script>` — print the full schema of one script.
 
-use crate::adapters::workspace_repository::FsWorkspaceRepository;
 use crate::cli::args::DescribeArgs;
 use crate::cli::json::{self, codes};
-use crate::cli::run::resolve_script_path;
-use crate::domain::Schema;
-use crate::error::{AppError, SchemaError};
-use crate::ports::ScriptRepository;
+use crate::operations::core::{self, DescribeScriptRequest, ScriptDescription};
+use crate::operations::{OperationError, OperationErrorCode};
 use crate::workspace::Workspace;
 use serde::Serialize;
 use serde_json::json;
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Serialize)]
 pub struct DescribePayload {
@@ -42,36 +39,40 @@ pub fn run(
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
     let workspace = Workspace::new(scripts_dir);
-    let resolved = match resolve_script_path(&options.script, workspace.root()) {
-        Ok(path) => path,
-        Err(err) => {
-            return emit_error(json_output, codes::NOT_FOUND, err.to_string());
-        }
-    };
-
-    let repo = FsWorkspaceRepository::new(workspace.root().to_path_buf());
-    let schema = match repo.read_schema(&resolved) {
-        Ok(schema) => schema,
-        Err(AppError::Schema(schema_err)) => {
-            let code = match schema_err {
-                SchemaError::BlockNotFound | SchemaError::JsonNotFound => codes::NOT_FOUND,
-                _ => codes::SCHEMA_INVALID,
-            };
-            return emit_error(json_output, code, schema_err.to_string());
-        }
-        Err(err) => {
-            return emit_error(json_output, codes::INTERNAL, err.to_string());
-        }
+    let description = match core::describe_script(
+        &workspace,
+        DescribeScriptRequest {
+            script: options.script,
+        },
+    ) {
+        Ok(description) => description,
+        Err(err) => return emit_operation_error(json_output, err),
     };
 
     if json_output {
-        let payload = build_payload(&resolved, workspace.root(), &schema);
-        json::print_ok(payload);
+        json::print_ok(payload_from_description(description));
         return Ok(());
     }
 
-    print_human(&resolved, workspace.root(), &schema);
+    print_human_payload(&payload_from_description(description));
     Ok(())
+}
+
+fn emit_operation_error(json_output: bool, err: OperationError) -> Result<(), Box<dyn Error>> {
+    let code = match err.code {
+        OperationErrorCode::NotFound => codes::NOT_FOUND,
+        OperationErrorCode::InvalidInput if is_missing_schema_message(&err.message) => {
+            codes::NOT_FOUND
+        }
+        OperationErrorCode::UnsafePath => codes::INVALID_ARGUMENT,
+        OperationErrorCode::InvalidInput => codes::SCHEMA_INVALID,
+        _ => codes::INTERNAL,
+    };
+    emit_error(json_output, code, err.message)
+}
+
+fn is_missing_schema_message(message: &str) -> bool {
+    message.contains("Schema block not found") || message.contains("Schema JSON object not found")
 }
 
 fn emit_error(json_output: bool, code: &str, message: String) -> Result<(), Box<dyn Error>> {
@@ -85,7 +86,12 @@ fn emit_error(json_output: bool, code: &str, message: String) -> Result<(), Box<
     Err(message.into())
 }
 
-pub(crate) fn build_payload(script_path: &Path, root: &Path, schema: &Schema) -> DescribePayload {
+#[cfg(test)]
+pub(crate) fn build_payload(
+    script_path: &std::path::Path,
+    root: &std::path::Path,
+    schema: &crate::domain::Schema,
+) -> DescribePayload {
     let mut fields: Vec<DescribeField> = schema
         .fields
         .iter()
@@ -122,8 +128,32 @@ pub(crate) fn build_payload(script_path: &Path, root: &Path, schema: &Schema) ->
     }
 }
 
-fn print_human(script_path: &Path, root: &Path, schema: &Schema) {
-    let payload = build_payload(script_path, root, schema);
+fn payload_from_description(description: ScriptDescription) -> DescribePayload {
+    DescribePayload {
+        absolute_path: description.absolute_path,
+        relative_path: description.relative_path,
+        name: description.schema.name,
+        description: description.schema.description,
+        tags: description.schema.tags,
+        fields: description
+            .schema
+            .fields
+            .into_iter()
+            .map(|field| DescribeField {
+                name: field.name,
+                prompt: field.prompt,
+                kind: field.kind,
+                order: field.order,
+                required: field.required,
+                arg: field.arg,
+                default: field.default,
+                choices: field.choices,
+            })
+            .collect(),
+    }
+}
+
+fn print_human_payload(payload: &DescribePayload) {
     println!("Script: {}", payload.absolute_path);
     println!("Name: {}", payload.name);
     if let Some(desc) = &payload.description {

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,32 +1,14 @@
-use crate::adapters::system_checks::{
-    ensure_bash_installed, ensure_git_installed, ensure_jq_installed, ensure_powershell_installed,
-    ensure_python_installed,
-};
-use crate::adapters::workspace_repository::FsWorkspaceRepository;
-use crate::ports::ScriptRepository;
+use crate::operations::doctor::{self, DoctorCheck, DoctorReport, SchemaCheckReport};
 use crate::workspace::Workspace;
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub fn run(scripts_dir: PathBuf) -> Result<(), Box<dyn Error>> {
-    let mut ok = true;
     let workspace = Workspace::new(scripts_dir);
+    let report = doctor::doctor_report(&workspace)?;
 
-    println!("Checks:");
-    ok &= print_required("git", ensure_git_installed());
-    ok &= print_required("bash", ensure_bash_installed());
-    ok &= print_required("jq", ensure_jq_installed());
-    print_optional("powershell", ensure_powershell_installed());
-    print_optional("python", ensure_python_installed());
-
-    print_workspace_path("workspace_root", workspace.root());
-    print_workspace_path("omakure_dir", workspace.omakure_dir());
-    print_workspace_path("history_dir", workspace.history_dir());
-    print_workspace_path("workspace_config", workspace.config_path());
-
-    print_schemas_check(workspace.root());
-
-    if !ok {
+    print_report(&report);
+    if !report.ok {
         println!("One or more checks failed.");
         std::process::exit(1);
     }
@@ -35,89 +17,111 @@ pub fn run(scripts_dir: PathBuf) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-/// Walk the workspace and try to parse each script's schema. Reports
-/// unparseable scripts as a non-blocking WARN so users discover broken
-/// schemas without opening the TUI.
-pub(crate) fn check_schemas(root: &Path) -> (usize, Vec<(PathBuf, String)>) {
-    let repo = FsWorkspaceRepository::new(root.to_path_buf());
-    let scripts = match repo.list_scripts_recursive() {
-        Ok(s) => s,
-        Err(_) => return (0, Vec::new()),
-    };
-    let total = scripts.len();
-    let mut failures = Vec::new();
-    for script in scripts {
-        if let Err(err) = repo.read_schema(&script) {
-            let rel = script.strip_prefix(root).unwrap_or(&script).to_path_buf();
-            failures.push((rel, err.to_string()));
+fn print_report(report: &DoctorReport) {
+    println!("Checks:");
+    for check in &report.dependencies {
+        if check.required {
+            print_required(check);
+        } else {
+            print_optional(check);
         }
     }
-    (total, failures)
+    for path in &report.workspace_paths {
+        if path.exists {
+            println!("  {}: OK - {}", path.label, path.path);
+        } else {
+            println!("  {}: WARN - {} (not created yet)", path.label, path.path);
+        }
+    }
+    print_schemas_report(&report.schemas);
 }
 
-fn print_schemas_check(root: &Path) {
-    let (total, failures) = check_schemas(root);
-    if total == 0 {
+#[cfg(test)]
+pub(crate) fn check_schemas(root: &std::path::Path) -> (usize, Vec<(PathBuf, String)>) {
+    let report = doctor::check_schemas(root);
+    (
+        report.total,
+        report
+            .failures
+            .into_iter()
+            .map(|failure| (failure.path, failure.error))
+            .collect(),
+    )
+}
+
+fn print_schemas_report(report: &SchemaCheckReport) {
+    if report.total == 0 {
         println!("  schemas: WARN - no scripts found");
         return;
     }
-    let parsed = total - failures.len();
-    if failures.is_empty() {
-        println!("  schemas: OK - {}/{} parseable", parsed, total);
+    if report.failures.is_empty() {
+        println!(
+            "  schemas: OK - {}/{} parseable",
+            report.parsed, report.total
+        );
         return;
     }
-    println!("  schemas: WARN - {}/{} invalid", failures.len(), total);
-    for (path, err) in failures {
-        println!("    {}: {}", path.display(), err);
+    println!(
+        "  schemas: WARN - {}/{} invalid",
+        report.failures.len(),
+        report.total
+    );
+    for failure in &report.failures {
+        println!("    {}: {}", failure.path.display(), failure.error);
     }
 }
 
-fn print_required<E: std::fmt::Display>(label: &str, result: Result<(), E>) -> bool {
-    match result {
-        Ok(()) => {
-            println!("  {}: OK", label);
-            true
-        }
-        Err(err) => {
-            println!("  {}: ERROR - {}", label, err);
-            false
-        }
-    }
-}
-
-fn print_optional<E: std::fmt::Display>(label: &str, result: Result<(), E>) {
-    match result {
-        Ok(()) => {
-            println!("  {}: OK", label);
-        }
-        Err(err) => {
-            println!("  {}: WARN - {}", label, err);
-        }
-    }
-}
-
-fn print_workspace_path(label: &str, path: &std::path::Path) {
-    if path.exists() {
-        println!("  {}: OK - {}", label, path.display());
+fn print_required(check: &DoctorCheck) -> bool {
+    if check.ok {
+        println!("  {}: OK", check.label);
+        true
     } else {
-        println!("  {}: WARN - {} (not created yet)", label, path.display());
+        println!(
+            "  {}: ERROR - {}",
+            check.label,
+            check.message.as_deref().unwrap_or("unknown error")
+        );
+        false
+    }
+}
+
+fn print_optional(check: &DoctorCheck) {
+    if check.ok {
+        println!("  {}: OK", check.label);
+    } else {
+        println!(
+            "  {}: WARN - {}",
+            check.label,
+            check.message.as_deref().unwrap_or("unknown error")
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::operations::doctor::{SchemaFailure, WorkspacePathCheck};
 
     #[test]
     fn test_print_required_ok() {
-        let result: Result<(), String> = Ok(());
-        assert!(print_required("test", result));
+        let check = DoctorCheck {
+            label: "test".into(),
+            required: true,
+            ok: true,
+            message: None,
+        };
+        assert!(print_required(&check));
     }
 
     #[test]
     fn test_print_required_err() {
-        let result: Result<(), String> = Err("fail".to_string());
-        assert!(!print_required("test", result));
+        let check = DoctorCheck {
+            label: "test".into(),
+            required: true,
+            ok: false,
+            message: Some("fail".into()),
+        };
+        assert!(!print_required(&check));
     }
 
     #[test]
@@ -127,23 +131,16 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
-
-        // Good script — parses cleanly.
         fs::write(
             root.join("good.sh"),
             "#!/bin/bash\n# OMAKURE_SCHEMA_START\n# {\"Name\": \"Good\", \"Fields\": []}\n# OMAKURE_SCHEMA_END\necho ok\n",
         )
         .unwrap();
-
-        // Good ps1 without Order — would have failed before the normalize fix;
-        // doctor must now report it as parseable.
         fs::write(
             root.join("teams.ps1"),
             "# OMAKURE_SCHEMA_START\n# {\"Name\": \"T\", \"Fields\": [{\"Name\": \"x\", \"Type\": \"string\"}]}\n# OMAKURE_SCHEMA_END\n",
         )
         .unwrap();
-
-        // Broken script — SCHEMA_START without SCHEMA_END.
         fs::write(
             root.join("broken.sh"),
             "#!/bin/bash\n# OMAKURE_SCHEMA_START\n# {\"Name\": \"Broken\"}\necho still open\n",
@@ -158,10 +155,37 @@ mod tests {
 
     #[test]
     fn test_check_schemas_empty_workspace_reports_zero() {
-        use tempfile::TempDir;
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
         let (total, failures) = check_schemas(tmp.path());
         assert_eq!(total, 0);
         assert!(failures.is_empty());
+    }
+
+    #[test]
+    fn print_report_handles_all_sections() {
+        let report = DoctorReport {
+            ok: true,
+            dependencies: vec![DoctorCheck {
+                label: "git".into(),
+                required: true,
+                ok: true,
+                message: None,
+            }],
+            workspace_paths: vec![WorkspacePathCheck {
+                label: "workspace_root".into(),
+                path: "/tmp".into(),
+                exists: true,
+            }],
+            schemas: SchemaCheckReport {
+                total: 1,
+                parsed: 0,
+                failures: vec![SchemaFailure {
+                    path: PathBuf::from("broken.sh"),
+                    error: "bad".into(),
+                }],
+            },
+        };
+
+        print_report(&report);
     }
 }

--- a/src/cli/help_ai.rs
+++ b/src/cli/help_ai.rs
@@ -50,7 +50,7 @@ is recorded in .history/runs.sqlite with actor, optional reason, full \
 argv, exit code, stdout, stderr, start/end timestamps, and a stable run_id.";
 
 const AI_VERBS: &[&str] = &[
-    "scripts", "describe", "search", "run", "init", "history", "queue", "battery", "trace",
+    "scripts", "describe", "search", "run", "init", "history", "queue", "battery", "api", "trace",
     "config", "help-ai",
 ];
 
@@ -82,6 +82,8 @@ fn build_payload() -> HelpAiPayload {
             "script_exists",
             "missing_required_field",
             "invalid_argument",
+            "invalid_input",
+            "unauthorized",
             "not_implemented",
             "internal",
             "already_exists",
@@ -93,6 +95,7 @@ fn build_payload() -> HelpAiPayload {
             "git_failed",
             "io_failed",
             "registry_invalid",
+            "payload_too_large",
         ],
         verbs,
         data_shapes: json!({
@@ -146,6 +149,13 @@ fn build_payload() -> HelpAiPayload {
                 "schema_version": SCHEMA_VERSION,
             }),
             "history_show": "Same shape as `run` data above (full RunRow including stdout/stderr).",
+            "api": json!({
+                "transport": "HTTP loopback/internal management API",
+                "auth": "Authorization: Bearer <OMAKURE_API_TOKEN>; /v1/health is unauthenticated",
+                "envelope": "Same { ok, data, error, schema_version } shape as CLI JSON.",
+                "body_limit": "1 MiB",
+                "reference": ".docs/http-api.md",
+            }),
             "config": json!({
                 "ok": true,
                 "data": {
@@ -238,6 +248,7 @@ mod tests {
         assert!(payload.error_codes.contains(&"schema_invalid"));
         assert!(payload.error_codes.contains(&"script_exists"));
         assert!(payload.error_codes.contains(&"missing_required_field"));
+        assert!(payload.error_codes.contains(&"payload_too_large"));
     }
 
     #[test]

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -5,15 +5,13 @@ use crate::cli::args::{
     HistoryTracesArgs,
 };
 use crate::cli::json::{self, codes};
-use crate::runs::{
-    self, format_run_timestamp, query_traces, RunFilters, RunRow, RunState, RunStateSet, RunStats,
-    TraceLevel, TraceRow,
-};
+use crate::operations::core::{self, ListRunsRequest, ListTracesRequest, ShowRunRequest};
+use crate::operations::{OperationError, OperationErrorCode};
+use crate::runs::{self, format_run_timestamp, RunRow, RunStats, TraceRow};
 use crate::workspace::Workspace;
 use serde::Serialize;
 use std::error::Error;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 /// Compact run row used by `history list --json`. Stdout/stderr are
 /// omitted to keep payloads small; agents that need them call
@@ -103,11 +101,6 @@ fn list(
         None
     };
 
-    let states = match resolve_state_filter(&opts.state, opts.state_set.as_deref()) {
-        Ok(states) => states,
-        Err(err) => return emit_error(json_output, codes::INVALID_ARGUMENT, err),
-    };
-
     let now = runs::current_unix_ms();
     let since_ms = match opts.since.as_deref().map(parse_duration_to_ms) {
         Some(Ok(d)) => Some(now - d),
@@ -120,20 +113,20 @@ fn list(
         None => None,
     };
 
-    let filters = RunFilters {
+    let request = ListRunsRequest {
         script: opts.script,
         actor: opts.actor,
         since_ms,
         until_ms,
         success,
         limit: opts.limit,
-        states,
+        states: opts.state,
+        state_set: opts.state_set,
     };
 
-    let conn = open_or_error(workspace, json_output)?;
-    let rows = match runs::query_runs(&conn, &filters) {
+    let rows = match core::list_runs(workspace, request) {
         Ok(rows) => rows,
-        Err(err) => return emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => return emit_operation_error(json_output, err),
     };
 
     if json_output {
@@ -164,30 +157,32 @@ fn format_list_row(row: &RunRow) -> String {
     )
 }
 
-/// Resolve the user-supplied `--state` and `--state-set` flags into a
-/// concrete list of [`RunState`] values for [`RunFilters::states`].
+/// Resolve the user-supplied `--state` and `--state-set` flags into concrete
+/// run states. Retained as characterization coverage for the operation-backed
+/// adapter migration.
 ///
-/// Default (neither flag): the [`RunStateSet::Terminal`] set, so v0.1
-/// callers see no behavior change.
+/// Default (neither flag): the terminal set, so v0.1 callers see no behavior
+/// change.
+#[cfg(test)]
 fn resolve_state_filter(
     states: &[String],
     state_set: Option<&str>,
-) -> Result<Vec<RunState>, String> {
+) -> Result<Vec<crate::runs::RunState>, String> {
     if !states.is_empty() && state_set.is_some() {
         return Err("--state and --state-set are mutually exclusive".to_string());
     }
     if let Some(set) = state_set {
-        let parsed: RunStateSet = set.parse()?;
+        let parsed: crate::runs::RunStateSet = set.parse()?;
         return Ok(parsed.to_states());
     }
     if !states.is_empty() {
         let mut out = Vec::with_capacity(states.len());
         for s in states {
-            out.push(s.parse::<RunState>()?);
+            out.push(s.parse::<crate::runs::RunState>()?);
         }
         return Ok(out);
     }
-    Ok(RunStateSet::Terminal.to_states())
+    Ok(crate::runs::RunStateSet::Terminal.to_states())
 }
 
 fn show(
@@ -195,17 +190,14 @@ fn show(
     opts: HistoryShowArgs,
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let conn = open_or_error(workspace, json_output)?;
-    let row = match runs::get_run(&conn, &opts.run_id) {
-        Ok(Some(row)) => row,
-        Ok(None) => {
-            return emit_error(
-                json_output,
-                codes::NOT_FOUND,
-                format!("run not found: {}", opts.run_id),
-            );
-        }
-        Err(err) => return emit_error(json_output, codes::INTERNAL, err),
+    let row = match core::show_run(
+        workspace,
+        ShowRunRequest {
+            run_id: opts.run_id,
+        },
+    ) {
+        Ok(row) => row,
+        Err(err) => return emit_operation_error(json_output, err),
     };
 
     if json_output {
@@ -298,10 +290,9 @@ fn tail(
 }
 
 fn stats(workspace: &Workspace, json_output: bool) -> Result<(), Box<dyn Error>> {
-    let conn = open_or_error(workspace, json_output)?;
-    let stats = match runs::stats(&conn) {
+    let stats = match core::run_stats(workspace) {
         Ok(s) => s,
-        Err(err) => return emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => return emit_operation_error(json_output, err),
     };
     if json_output {
         json::print_ok(stats);
@@ -337,25 +328,24 @@ fn traces(
     opts: HistoryTracesArgs,
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let level_min = match opts.level.as_deref() {
-        None => None,
-        Some(s) => match TraceLevel::from_str(s) {
-            Ok(l) => Some(l),
-            Err(err) => return emit_error(json_output, codes::INVALID_ARGUMENT, err),
+    let run_id = opts.run_id;
+    let traces = match core::list_traces(
+        workspace,
+        ListTracesRequest {
+            run_id: run_id.clone(),
+            level: opts.level,
+            since_sequence: opts.since_sequence,
         },
-    };
-
-    let conn = open_or_error(workspace, json_output)?;
-    let traces = match query_traces(&conn, &opts.run_id, level_min, opts.since_sequence) {
+    ) {
         Ok(rows) => rows,
-        Err(err) if err.starts_with("not_found") => {
+        Err(err) if err.code == OperationErrorCode::NotFound => {
             return emit_error(
                 json_output,
                 codes::NOT_FOUND,
-                format!("run not found: {}", opts.run_id),
+                format!("run not found: {}", run_id),
             );
         }
-        Err(err) => return emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => return emit_operation_error(json_output, err),
     };
 
     if json_output {
@@ -389,22 +379,21 @@ fn format_trace_row(trace: &TraceRow) -> String {
     }
 }
 
-fn open_or_error(
-    workspace: &Workspace,
-    json_output: bool,
-) -> Result<rusqlite::Connection, Box<dyn Error>> {
-    match runs::open(workspace) {
-        Ok(conn) => Ok(conn),
-        Err(err) => Err(emit_error(json_output, codes::INTERNAL, err).unwrap_err()),
-    }
-}
-
 fn emit_error(json_output: bool, code: &str, message: String) -> Result<(), Box<dyn Error>> {
     if json_output {
         json::print_err(code, message);
         std::process::exit(1);
     }
     Err(message.into())
+}
+
+fn emit_operation_error(json_output: bool, err: OperationError) -> Result<(), Box<dyn Error>> {
+    let code = match err.code {
+        OperationErrorCode::InvalidInput => codes::INVALID_ARGUMENT,
+        OperationErrorCode::NotFound => codes::NOT_FOUND,
+        _ => codes::INTERNAL,
+    };
+    emit_error(json_output, code, err.message)
 }
 
 /// Parse a relative-duration string like `30s`, `15m`, `2h`, `7d` into
@@ -434,6 +423,7 @@ pub fn parse_duration_to_ms(s: &str) -> Result<i64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runs::{RunState, RunStateSet};
     use std::collections::HashMap;
     use tempfile::TempDir;
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,8 +1,7 @@
-use crate::adapters::workspace_repository::FsWorkspaceRepository;
 use crate::cli::args::ScriptsArgs;
 use crate::cli::json;
-use crate::ports::ScriptRepository;
-use serde::Serialize;
+use crate::operations::core::{self, ListScriptsRequest};
+use crate::workspace::Workspace;
 use std::error::Error;
 use std::path::PathBuf;
 
@@ -10,31 +9,15 @@ use std::path::PathBuf;
 ///
 /// This is the same shape used by `omakure search --json` so an agent can
 /// pipe results between the two commands without translating fields.
-#[derive(Debug, Serialize)]
-pub struct ScriptListEntry {
-    pub absolute_path: String,
-    pub relative_path: String,
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub tags: Vec<String>,
-    pub field_count: usize,
-    pub schema_error: Option<String>,
-}
+pub type ScriptListEntry = core::ScriptSummary;
 
 pub fn run(
     scripts_dir: PathBuf,
     args: ScriptsArgs,
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let repo = FsWorkspaceRepository::new(scripts_dir.clone());
-    let mut scripts = repo.list_scripts_recursive()?;
-    scripts.sort();
-
-    let entries: Vec<ScriptListEntry> = scripts
-        .into_iter()
-        .map(|script| build_entry(&repo, &scripts_dir, script))
-        .filter(|entry| matches_all_tags(entry, &args.tag))
-        .collect();
+    let workspace = Workspace::new(scripts_dir.clone());
+    let entries = core::list_scripts(&workspace, ListScriptsRequest { tags: args.tag })?;
 
     if json_output {
         json::print_ok(entries);
@@ -62,48 +45,12 @@ pub fn run(
 /// Test/internal helper: returns true when `entry` carries every tag in
 /// `required` (case-sensitive literal AND match). When `required` is
 /// empty, every entry passes.
+#[cfg(test)]
 pub(crate) fn matches_all_tags(entry: &ScriptListEntry, required: &[String]) -> bool {
     if required.is_empty() {
         return true;
     }
     required.iter().all(|t| entry.tags.iter().any(|et| et == t))
-}
-
-fn build_entry(
-    repo: &FsWorkspaceRepository,
-    root: &std::path::Path,
-    script: PathBuf,
-) -> ScriptListEntry {
-    let relative_path = script
-        .strip_prefix(root)
-        .unwrap_or(&script)
-        .to_string_lossy()
-        .to_string();
-    let absolute_path = std::fs::canonicalize(&script)
-        .unwrap_or_else(|_| script.clone())
-        .to_string_lossy()
-        .to_string();
-
-    match repo.read_schema(&script) {
-        Ok(schema) => ScriptListEntry {
-            absolute_path,
-            relative_path,
-            name: Some(schema.name),
-            description: schema.description,
-            tags: schema.tags.unwrap_or_default(),
-            field_count: schema.fields.len(),
-            schema_error: None,
-        },
-        Err(err) => ScriptListEntry {
-            absolute_path,
-            relative_path,
-            name: None,
-            description: None,
-            tags: Vec::new(),
-            field_count: 0,
-            schema_error: Some(err.to_string()),
-        },
-    }
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod args;
 pub mod battery;
 pub mod config;

--- a/src/cli/queue.rs
+++ b/src/cli/queue.rs
@@ -9,14 +9,14 @@
 //! with the synchronous `omakure run` fast path via
 //! [`crate::run_executor::execute_with_heartbeat`].
 
-use crate::app_meta;
 use crate::cli::args::{
     QueueAddArgs, QueueArgs, QueueCancelArgs, QueueCommand, QueueDeadLetterArgs, QueueWorkerArgs,
 };
 use crate::cli::json::{self, codes};
-use crate::cli::run::resolve_script_path;
+use crate::operations::core::{self, CancelRunRequest, DeadLetterRunRequest, EnqueueRunRequest};
+use crate::operations::{OperationError, OperationErrorCode};
 use crate::run_executor::{execute_with_heartbeat, ExecutionTerminal};
-use crate::runs::{self, ClaimFilters, EnqueueOptions, RunCompletion, RunRow};
+use crate::runs::{self, ClaimFilters, RunCompletion, RunRow};
 use crate::workspace::Workspace;
 use serde_json::json;
 use std::error::Error;
@@ -46,11 +46,6 @@ pub fn run(scripts_dir: PathBuf, args: QueueArgs, json_output: bool) -> Result<(
 // ---------------------------------------------------------------------------
 
 fn add(workspace: &Workspace, opts: QueueAddArgs, json_output: bool) -> Result<(), Box<dyn Error>> {
-    let script_path = match resolve_script_path(&opts.script, workspace.root()) {
-        Ok(p) => p,
-        Err(err) => return emit_error(json_output, codes::NOT_FOUND, err.to_string()),
-    };
-
     let timeout_ms = match opts.timeout.as_deref() {
         None => None,
         Some(s) => match parse_duration_ms(s) {
@@ -59,13 +54,11 @@ fn add(workspace: &Workspace, opts: QueueAddArgs, json_output: bool) -> Result<(
         },
     };
 
-    let conn = open_or_error(workspace, json_output)?;
-    let canonical = std::fs::canonicalize(&script_path).unwrap_or(script_path.clone());
-    let row = match runs::enqueue(
-        &conn,
-        canonical.to_string_lossy().as_ref(),
-        &opts.args,
-        EnqueueOptions {
+    let row = match core::enqueue_run(
+        workspace,
+        EnqueueRunRequest {
+            script: opts.script,
+            args: opts.args,
             run_id: opts.run_id,
             actor: opts.actor,
             reason: opts.reason,
@@ -73,13 +66,10 @@ fn add(workspace: &Workspace, opts: QueueAddArgs, json_output: bool) -> Result<(
             timeout_ms,
             parent_run_id: opts.parent_run_id,
             cron_schedule_id: opts.cron_schedule_id,
-            script_name: None,
-            omakure_version: app_meta::APP_VERSION.to_string(),
-            trigger: crate::runs::RunTrigger::Manual,
         },
     ) {
         Ok(row) => row,
-        Err(err) => return emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => return emit_operation_error(json_output, err),
     };
     if json_output {
         json::print_ok(row);
@@ -94,18 +84,13 @@ fn cancel(
     opts: QueueCancelArgs,
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let conn = open_or_error(workspace, json_output)?;
-    if runs::get_run(&conn, &opts.run_id)
-        .map_err(Box::<dyn Error>::from)?
-        .is_none()
-    {
-        return emit_error(
-            json_output,
-            codes::NOT_FOUND,
-            format!("run not found: {}", opts.run_id),
-        );
-    }
-    match runs::cancel(&conn, &opts.run_id, opts.reason, None) {
+    match core::cancel_run(
+        workspace,
+        CancelRunRequest {
+            run_id: opts.run_id,
+            reason: opts.reason,
+        },
+    ) {
         Ok(row) => {
             if json_output {
                 json::print_ok(row);
@@ -114,10 +99,7 @@ fn cancel(
             }
             Ok(())
         }
-        Err(err) if err.contains("terminal state") => {
-            emit_error(json_output, codes::INVALID_ARGUMENT, err)
-        }
-        Err(err) => emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => emit_operation_error(json_output, err),
     }
 }
 
@@ -126,18 +108,13 @@ fn dead_letter(
     opts: QueueDeadLetterArgs,
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let conn = open_or_error(workspace, json_output)?;
-    if runs::get_run(&conn, &opts.run_id)
-        .map_err(Box::<dyn Error>::from)?
-        .is_none()
-    {
-        return emit_error(
-            json_output,
-            codes::NOT_FOUND,
-            format!("run not found: {}", opts.run_id),
-        );
-    }
-    match runs::dead_letter(&conn, &opts.run_id, opts.reason) {
+    match core::dead_letter_run(
+        workspace,
+        DeadLetterRunRequest {
+            run_id: opts.run_id,
+            reason: opts.reason,
+        },
+    ) {
         Ok(row) => {
             if json_output {
                 json::print_ok(row);
@@ -146,18 +123,14 @@ fn dead_letter(
             }
             Ok(())
         }
-        Err(err) if err.contains("only failed or timed_out") => {
-            emit_error(json_output, codes::INVALID_ARGUMENT, err)
-        }
-        Err(err) => emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => emit_operation_error(json_output, err),
     }
 }
 
 fn stats(workspace: &Workspace, json_output: bool) -> Result<(), Box<dyn Error>> {
-    let conn = open_or_error(workspace, json_output)?;
-    let stats = match runs::stats(&conn) {
+    let stats = match core::queue_stats(workspace) {
         Ok(s) => s,
-        Err(err) => return emit_error(json_output, codes::INTERNAL, err),
+        Err(err) => return emit_operation_error(json_output, err),
     };
     if json_output {
         json::print_ok(stats);
@@ -319,22 +292,23 @@ fn parse_duration_ms(s: &str) -> Result<i64, String> {
     Ok(ms as i64)
 }
 
-fn open_or_error(
-    workspace: &Workspace,
-    json_output: bool,
-) -> Result<rusqlite::Connection, Box<dyn Error>> {
-    match runs::open(workspace) {
-        Ok(conn) => Ok(conn),
-        Err(err) => Err(emit_error(json_output, codes::INTERNAL, err).unwrap_err()),
-    }
-}
-
 fn emit_error(json_output: bool, code: &str, message: String) -> Result<(), Box<dyn Error>> {
     if json_output {
         json::print_err(code, message);
         std::process::exit(1);
     }
     Err(message.into())
+}
+
+fn emit_operation_error(json_output: bool, err: OperationError) -> Result<(), Box<dyn Error>> {
+    let code = match err.code {
+        OperationErrorCode::InvalidInput
+        | OperationErrorCode::UnsafePath
+        | OperationErrorCode::Conflict => codes::INVALID_ARGUMENT,
+        OperationErrorCode::NotFound => codes::NOT_FOUND,
+        _ => codes::INTERNAL,
+    };
+    emit_error(json_output, code, err.message)
 }
 
 // Used by tests to make captured-output assertions.
@@ -357,7 +331,7 @@ pub(crate) fn make_completion(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runs::{enqueue, RunState};
+    use crate::runs::{enqueue, EnqueueOptions, RunState};
     use std::fs;
     use std::path::PathBuf;
 

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,9 +1,10 @@
 //! `omakure search <query>` — surface the SQLite-backed script index.
 
 use crate::cli::args::SearchArgs;
-use crate::cli::json;
+use crate::cli::json::{self, codes};
 use crate::cli::list::ScriptListEntry;
-use crate::search_index::{SearchIndex, SearchResult};
+use crate::operations::search::{self, SearchScriptsRequest};
+use crate::operations::{OperationError, OperationErrorCode};
 use crate::workspace::Workspace;
 use std::error::Error;
 use std::path::PathBuf;
@@ -14,32 +15,17 @@ pub fn run(
     json_output: bool,
 ) -> Result<(), Box<dyn Error>> {
     let workspace = Workspace::new(scripts_dir);
-    workspace.ensure_layout()?;
-
-    let index = SearchIndex::new(workspace.search_db_path());
-    // The search index normally rebuilds in the background from the TUI.
-    // For one-shot CLI use we trigger the rebuild and block on it so the
-    // results are always fresh, even on a workspace that has never opened
-    // the TUI.
-    index.start_background_rebuild(workspace.root().to_path_buf());
-    block_until_ready(&index);
-
-    let results = match index.query(&options.query) {
-        Ok(results) => results,
-        Err(err) => {
-            if json_output {
-                json::print_err(crate::cli::json::codes::INTERNAL, err.clone());
-                std::process::exit(1);
-            }
-            return Err(err.into());
-        }
+    let entries = match search::search_scripts(
+        &workspace,
+        SearchScriptsRequest {
+            query: options.query,
+            tags: options.tag,
+            refresh: true,
+        },
+    ) {
+        Ok(entries) => entries,
+        Err(err) => return emit_operation_error(json_output, err),
     };
-
-    let entries: Vec<ScriptListEntry> = results
-        .into_iter()
-        .map(|r| to_entry(r, workspace.root()))
-        .filter(|entry| crate::cli::list::matches_all_tags(entry, &options.tag))
-        .collect();
 
     if json_output {
         json::print_ok(entries);
@@ -51,128 +37,62 @@ pub fn run(
         return Ok(());
     }
     for entry in entries {
-        let desc = entry.description.as_deref().unwrap_or("");
-        if desc.is_empty() {
-            println!(" - {}", entry.relative_path);
-        } else {
-            println!(" - {} — {}", entry.relative_path, desc);
-        }
+        print_entry(&entry);
     }
     Ok(())
 }
 
-fn to_entry(r: SearchResult, root: &std::path::Path) -> ScriptListEntry {
-    // The search index stores workspace-relative paths. Join with the
-    // root before canonicalizing so the JSON `absolute_path` is always a
-    // real absolute filesystem path.
-    let joined = if r.script_path.is_absolute() {
-        r.script_path.clone()
+fn print_entry(entry: &ScriptListEntry) {
+    let desc = entry.description.as_deref().unwrap_or("");
+    if desc.is_empty() {
+        println!(" - {}", entry.relative_path);
     } else {
-        root.join(&r.script_path)
-    };
-    let absolute_path = std::fs::canonicalize(&joined)
-        .unwrap_or(joined)
-        .to_string_lossy()
-        .to_string();
-    let relative_path = r.script_path.to_string_lossy().to_string();
-    ScriptListEntry {
-        absolute_path,
-        relative_path,
-        name: Some(r.display_name),
-        description: r.description,
-        tags: r.tags,
-        field_count: 0,
-        schema_error: r.schema_error,
+        println!(" - {} — {}", entry.relative_path, desc);
     }
 }
 
-fn block_until_ready(index: &SearchIndex) {
-    use crate::search_index::SearchStatus;
-    use std::thread;
-    use std::time::Duration;
-    // Bounded wait — the index rebuild for a typical workspace finishes in
-    // milliseconds. We cap at ~5s so a wedged background thread cannot
-    // hang the CLI.
-    for _ in 0..50 {
-        match index.status() {
-            SearchStatus::Ready { .. } | SearchStatus::Error(_) => return,
-            _ => thread::sleep(Duration::from_millis(100)),
-        }
+fn emit_operation_error(json_output: bool, err: OperationError) -> Result<(), Box<dyn Error>> {
+    let code = match err.code {
+        OperationErrorCode::InvalidInput => codes::INVALID_ARGUMENT,
+        _ => codes::INTERNAL,
+    };
+    if json_output {
+        json::print_err(code, err.message);
+        std::process::exit(1);
     }
+    Err(err.message.into())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::search_index::SearchStatus;
     use pretty_assertions::assert_eq;
-    use tempfile::TempDir;
 
-    fn result(path: PathBuf, display_name: &str) -> SearchResult {
-        SearchResult {
-            script_path: path,
-            display_name: display_name.to_string(),
-            description: Some("Deploy app".to_string()),
-            tags: vec!["ops".to_string()],
+    #[test]
+    fn print_entry_accepts_entries_with_and_without_descriptions() {
+        print_entry(&ScriptListEntry {
+            absolute_path: "/tmp/deploy.sh".into(),
+            relative_path: "deploy.sh".into(),
+            name: Some("Deploy".into()),
+            description: Some("Ship app".into()),
+            tags: vec!["ops".into()],
+            field_count: 0,
             schema_error: None,
-        }
-    }
-
-    #[test]
-    fn to_entry_joins_relative_path_and_canonicalizes() {
-        let tmp = TempDir::new().unwrap();
-        let script = tmp.path().join("deploy.sh");
-        std::fs::write(&script, "#!/usr/bin/env bash\n").unwrap();
-
-        let entry = to_entry(result(PathBuf::from("deploy.sh"), "Deploy"), tmp.path());
-
-        assert_eq!(entry.relative_path, "deploy.sh");
-        assert_eq!(entry.absolute_path, script.to_string_lossy().to_string());
-        assert_eq!(entry.name, Some("Deploy".to_string()));
-        assert_eq!(entry.description, Some("Deploy app".to_string()));
-        assert_eq!(entry.tags, vec!["ops".to_string()]);
-    }
-
-    #[test]
-    fn to_entry_preserves_absolute_path_when_input_is_absolute() {
-        let tmp = TempDir::new().unwrap();
-        let script = tmp.path().join("deploy.sh");
-        std::fs::write(&script, "#!/usr/bin/env bash\n").unwrap();
-
-        let entry = to_entry(result(script.clone(), "Deploy"), tmp.path());
-
-        assert_eq!(entry.relative_path, script.to_string_lossy().to_string());
-        assert_eq!(entry.absolute_path, script.to_string_lossy().to_string());
-    }
-
-    #[test]
-    fn to_entry_falls_back_to_joined_path_when_target_is_missing() {
-        let tmp = TempDir::new().unwrap();
-        let joined = tmp.path().join("missing.sh");
-
-        let entry = to_entry(result(PathBuf::from("missing.sh"), "Missing"), tmp.path());
-
-        assert_eq!(entry.absolute_path, joined.to_string_lossy().to_string());
-        assert_eq!(entry.relative_path, "missing.sh");
-    }
-
-    #[test]
-    fn block_until_ready_stops_when_index_reports_ready() {
-        let tmp = TempDir::new().unwrap();
-        let script = tmp.path().join("deploy.sh");
-        std::fs::write(&script, "#!/usr/bin/env bash\n").unwrap();
-        let db_path = tmp.path().join("search.sqlite");
-        let index = SearchIndex::new(db_path);
-
-        index.start_background_rebuild(tmp.path().to_path_buf());
-        block_until_ready(&index);
-
-        assert_eq!(index.status(), SearchStatus::Ready { script_count: 1 });
+        });
+        print_entry(&ScriptListEntry {
+            absolute_path: "/tmp/bare.sh".into(),
+            relative_path: "bare.sh".into(),
+            name: Some("Bare".into()),
+            description: None,
+            tags: Vec::new(),
+            field_count: 0,
+            schema_error: None,
+        });
     }
 
     #[test]
     fn run_human_format_no_matches() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
         run(
             tmp.path().to_path_buf(),
             SearchArgs {
@@ -186,7 +106,7 @@ mod tests {
 
     #[test]
     fn run_json_format_with_results() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join("deploy.sh"),
             "#!/usr/bin/env bash\n# OMAKURE_SCHEMA_START\n# {\"Name\":\"Deploy\",\"Description\":\"Ship\",\"Tags\":[\"ops\"],\"Fields\":[]}\n# OMAKURE_SCHEMA_END\n",
@@ -204,34 +124,17 @@ mod tests {
     }
 
     #[test]
-    fn run_human_format_with_results_and_descriptions() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(
-            tmp.path().join("deploy.sh"),
-            "#!/usr/bin/env bash\n# OMAKURE_SCHEMA_START\n# {\"Name\":\"Deploy\",\"Description\":\"Ship\",\"Fields\":[]}\n# OMAKURE_SCHEMA_END\n",
-        )
-        .unwrap();
-        std::fs::write(tmp.path().join("bare.sh"), "#!/usr/bin/env bash\n").unwrap();
-        run(
-            tmp.path().to_path_buf(),
-            SearchArgs {
-                query: String::new(),
-                tag: vec![],
-            },
-            false,
-        )
-        .unwrap();
-    }
+    fn operation_result_preserves_script_list_shape() {
+        let entry = ScriptListEntry {
+            absolute_path: "/tmp/deploy.sh".into(),
+            relative_path: "deploy.sh".into(),
+            name: Some("Deploy".into()),
+            description: Some("Ship app".into()),
+            tags: vec!["ops".into()],
+            field_count: 0,
+            schema_error: None,
+        };
 
-    #[test]
-    fn block_until_ready_stops_when_index_reports_error() {
-        let tmp = TempDir::new().unwrap();
-        let db_path = tmp.path().to_path_buf();
-        let index = SearchIndex::new(db_path);
-
-        index.start_background_rebuild(tmp.path().to_path_buf());
-        block_until_ready(&index);
-
-        assert!(matches!(index.status(), SearchStatus::Error(_)));
+        assert_eq!(entry.relative_path, "deploy.sh");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         Some(Commands::History(args)) => cli::history::run(global_root, args, json_output)?,
         Some(Commands::Queue(args)) => cli::queue::run(global_root, args, json_output)?,
         Some(Commands::Battery(args)) => cli::battery::run(global_root, args, json_output)?,
+        Some(Commands::Api(args)) => cli::api::run(global_root, args)?,
         Some(Commands::Trace(args)) => cli::trace::run(global_root, args, json_output)?,
         Some(Commands::HelpAi) => cli::help_ai::run()?,
         Some(Commands::Run(args)) => cli::run::run(global_root, args, json_output)?,

--- a/src/operations/battery.rs
+++ b/src/operations/battery.rs
@@ -236,6 +236,21 @@ pub fn sync_battery(
     workspace: &Workspace,
     request: SyncBatteryRequest,
 ) -> OperationResult<BatterySummary> {
+    sync_battery_with_policy(workspace, request, GitTransportPolicy::Default)
+}
+
+pub fn sync_battery_https_only(
+    workspace: &Workspace,
+    request: SyncBatteryRequest,
+) -> OperationResult<BatterySummary> {
+    sync_battery_with_policy(workspace, request, GitTransportPolicy::HttpsOnly)
+}
+
+fn sync_battery_with_policy(
+    workspace: &Workspace,
+    request: SyncBatteryRequest,
+    policy: GitTransportPolicy,
+) -> OperationResult<BatterySummary> {
     let paths = BatteryPaths::for_workspace(workspace);
     let mut registry = read_registry(&paths.registry_path)?;
     validate_battery_name(&request.name)?;
@@ -261,40 +276,46 @@ pub fn sync_battery(
                 )
             })?;
         }
-        run_git(git_clone_spec(
-            &registry.batteries[index].git_url,
-            &cache_path,
-        ))?;
+        run_git_with_policy(
+            git_clone_spec(&registry.batteries[index].git_url, &cache_path),
+            policy,
+        )?;
         reject_unsafe_local_git_config(&cache_path)?;
     } else {
-        verify_cache_origin(&cache_path, &registry.batteries[index].git_url)?;
+        verify_cache_origin_with_policy(&cache_path, &registry.batteries[index].git_url, policy)?;
     }
-    run_git(git_fetch_spec(
-        &cache_path,
-        &registry.batteries[index].requested_ref,
-    ))?;
-    let fetched_commit = run_git_capture(GitCommandSpec {
-        program: "git".into(),
-        args: vec![
-            "-C".into(),
-            cache_path.display().to_string(),
-            "rev-parse".into(),
-            "FETCH_HEAD^{commit}".into(),
-        ],
-    })?;
-    run_git(git_checkout_detached_spec(
-        &cache_path,
-        fetched_commit.trim(),
-    ))?;
-    let resolved_commit = run_git_capture(GitCommandSpec {
-        program: "git".into(),
-        args: vec![
-            "-C".into(),
-            cache_path.display().to_string(),
-            "rev-parse".into(),
-            "HEAD".into(),
-        ],
-    })?
+    run_git_with_policy(
+        git_fetch_spec(&cache_path, &registry.batteries[index].requested_ref),
+        policy,
+    )?;
+    let fetched_commit = run_git_capture_with_policy(
+        GitCommandSpec {
+            program: "git".into(),
+            args: vec![
+                "-C".into(),
+                cache_path.display().to_string(),
+                "rev-parse".into(),
+                "FETCH_HEAD^{commit}".into(),
+            ],
+        },
+        policy,
+    )?;
+    run_git_with_policy(
+        git_checkout_detached_spec(&cache_path, fetched_commit.trim()),
+        policy,
+    )?;
+    let resolved_commit = run_git_capture_with_policy(
+        GitCommandSpec {
+            program: "git".into(),
+            args: vec![
+                "-C".into(),
+                cache_path.display().to_string(),
+                "rev-parse".into(),
+                "HEAD".into(),
+            ],
+        },
+        policy,
+    )?
     .trim()
     .to_string();
     let manifest = load_manifest(&cache_path)?;
@@ -645,18 +666,25 @@ fn validate_git_ref(value: &str) -> OperationResult<()> {
     Ok(())
 }
 
-fn verify_cache_origin(cache_path: &Path, expected_url: &str) -> OperationResult<()> {
+fn verify_cache_origin_with_policy(
+    cache_path: &Path,
+    expected_url: &str,
+    policy: GitTransportPolicy,
+) -> OperationResult<()> {
     reject_unsafe_local_git_config(cache_path)?;
-    let actual = run_git_capture(GitCommandSpec {
-        program: "git".into(),
-        args: vec![
-            "-C".into(),
-            cache_path.display().to_string(),
-            "remote".into(),
-            "get-url".into(),
-            "origin".into(),
-        ],
-    })?
+    let actual = run_git_capture_with_policy(
+        GitCommandSpec {
+            program: "git".into(),
+            args: vec![
+                "-C".into(),
+                cache_path.display().to_string(),
+                "remote".into(),
+                "get-url".into(),
+                "origin".into(),
+            ],
+        },
+        policy,
+    )?
     .trim()
     .to_string();
     if actual != expected_url {
@@ -703,8 +731,8 @@ fn sanitize_file_component(value: &str) -> String {
         .collect()
 }
 
-fn run_git(spec: GitCommandSpec) -> OperationResult<()> {
-    let output = git_command(&spec).output().map_err(|err| {
+fn run_git_with_policy(spec: GitCommandSpec, policy: GitTransportPolicy) -> OperationResult<()> {
+    let output = git_command(&spec, policy).output().map_err(|err| {
         OperationError::new(
             OperationErrorCode::GitFailed,
             format!("failed to spawn git: {err}"),
@@ -721,7 +749,14 @@ fn run_git(spec: GitCommandSpec) -> OperationResult<()> {
 }
 
 fn run_git_capture(spec: GitCommandSpec) -> OperationResult<String> {
-    let output = git_command(&spec).output().map_err(|err| {
+    run_git_capture_with_policy(spec, GitTransportPolicy::Default)
+}
+
+fn run_git_capture_with_policy(
+    spec: GitCommandSpec,
+    policy: GitTransportPolicy,
+) -> OperationResult<String> {
+    let output = git_command(&spec, policy).output().map_err(|err| {
         OperationError::new(
             OperationErrorCode::GitFailed,
             format!("failed to spawn git: {err}"),
@@ -737,7 +772,7 @@ fn run_git_capture(spec: GitCommandSpec) -> OperationResult<String> {
     }
 }
 
-fn git_command(spec: &GitCommandSpec) -> Command {
+fn git_command(spec: &GitCommandSpec, policy: GitTransportPolicy) -> Command {
     let mut command = Command::new(&spec.program);
     command
         .args(&spec.args)
@@ -745,7 +780,7 @@ fn git_command(spec: &GitCommandSpec) -> Command {
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_CONFIG_GLOBAL", git_null_config_path())
         .env("GIT_CONFIG_SYSTEM", git_null_config_path())
-        .env("GIT_ALLOW_PROTOCOL", "file:https:http")
+        .env("GIT_ALLOW_PROTOCOL", policy.allowed_protocols())
         .env_remove("GIT_ASKPASS")
         .env_remove("SSH_ASKPASS")
         .env_remove("GIT_SSH")
@@ -757,7 +792,8 @@ fn git_command(spec: &GitCommandSpec) -> Command {
         .env_remove("XDG_CONFIG_DIRS")
         .env_remove("GIT_CONFIG")
         .env_remove("GIT_CONFIG_COUNT")
-        .env_remove("GIT_CONFIG_PARAMETERS");
+        .env_remove("GIT_CONFIG_PARAMETERS")
+        .env_remove("OMAKURE_API_TOKEN");
     command
 }
 
@@ -948,6 +984,21 @@ impl BatteryPaths {
 pub struct GitCommandSpec {
     pub program: String,
     pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GitTransportPolicy {
+    Default,
+    HttpsOnly,
+}
+
+impl GitTransportPolicy {
+    fn allowed_protocols(self) -> &'static str {
+        match self {
+            Self::Default => "file:https:http",
+            Self::HttpsOnly => "https",
+        }
+    }
 }
 
 pub fn read_registry(path: &Path) -> OperationResult<BatteryRegistry> {
@@ -2137,6 +2188,21 @@ echo ok
     }
 
     #[test]
+    fn git_command_removes_api_token() {
+        let command = git_command(
+            &GitCommandSpec {
+                program: "git".into(),
+                args: vec!["status".into()],
+            },
+            GitTransportPolicy::Default,
+        );
+
+        assert!(command
+            .get_envs()
+            .any(|(k, v)| k == "OMAKURE_API_TOKEN" && v.is_none()));
+    }
+
+    #[test]
     fn missing_registry_reads_as_empty_versioned_registry() {
         let dir = TempDir::new().unwrap();
         let registry = read_registry(&dir.path().join(".omakure/batteries.json")).unwrap();
@@ -2427,11 +2493,14 @@ path = "scripts/ignored.sh"
             program: "git".into(),
             args: vec!["status".into()],
         };
-        let command = git_command(&spec);
+        let command = git_command(&spec, GitTransportPolicy::Default);
         let envs: Vec<_> = command.get_envs().collect();
 
         assert!(envs.iter().any(|(key, value)| {
             *key == "GIT_TERMINAL_PROMPT" && value.map(|v| v == "0").unwrap_or(false)
+        }));
+        assert!(envs.iter().any(|(key, value)| {
+            *key == "GIT_ALLOW_PROTOCOL" && value.map(|v| v == "file:https:http").unwrap_or(false)
         }));
         assert!(envs
             .iter()
@@ -2477,6 +2546,20 @@ path = "scripts/ignored.sh"
         assert!(envs
             .iter()
             .any(|(key, value)| *key == "GIT_CONFIG_PARAMETERS" && value.is_none()));
+    }
+
+    #[test]
+    fn git_command_can_restrict_protocols_to_https() {
+        let spec = GitCommandSpec {
+            program: "git".into(),
+            args: vec!["status".into()],
+        };
+        let command = git_command(&spec, GitTransportPolicy::HttpsOnly);
+        let envs: Vec<_> = command.get_envs().collect();
+
+        assert!(envs.iter().any(|(key, value)| {
+            *key == "GIT_ALLOW_PROTOCOL" && value.map(|v| v == "https").unwrap_or(false)
+        }));
     }
 
     #[cfg(unix)]

--- a/src/operations/config.rs
+++ b/src/operations/config.rs
@@ -1,0 +1,257 @@
+use crate::adapters::environments::{
+    is_sensitive_key, resolve_active_env, should_mask_env_value, FsEnvironmentRepository,
+    MASKED_ENV_VALUE,
+};
+use crate::app_meta;
+use crate::ports::EnvironmentRepository;
+use crate::runtime::{python_program, resolve_interpreter};
+use crate::workspace::Workspace;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::env;
+use std::path::Path;
+
+use super::{OperationError, OperationErrorCode, OperationResult};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigSummary {
+    pub version: String,
+    pub binary: String,
+    pub workspace_root: String,
+    pub scripts_root: String,
+    pub omakure_dir: String,
+    pub history_dir: String,
+    pub workspace_config: String,
+    pub envs_dir: String,
+    pub envs_active_path: String,
+    pub active_env: Option<String>,
+    pub bootstrap_mode: String,
+    pub env_overrides: BTreeMap<String, String>,
+    pub active_env_keys: Vec<EnvVarView>,
+    pub interpreter: InterpreterView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvVarView {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InterpreterView {
+    pub program: String,
+    pub path: Option<String>,
+}
+
+pub fn config_summary(workspace: &Workspace) -> OperationResult<ConfigSummary> {
+    let exe = env::current_exe()
+        .map_err(|err| OperationError::new(OperationErrorCode::IoFailed, err.to_string()))?;
+    let active_env = read_active_env(workspace);
+    let (active_env_keys, interpreter) = resolve_env_diagnostics(workspace.envs_dir());
+
+    Ok(ConfigSummary {
+        version: app_meta::APP_VERSION.to_string(),
+        binary: exe.display().to_string(),
+        workspace_root: workspace.root().display().to_string(),
+        scripts_root: workspace.scripts_root().display().to_string(),
+        omakure_dir: workspace.omakure_dir().display().to_string(),
+        history_dir: workspace.history_dir().display().to_string(),
+        workspace_config: workspace.config_path().display().to_string(),
+        envs_dir: workspace.envs_dir().display().to_string(),
+        envs_active_path: workspace.envs_active_path().display().to_string(),
+        active_env,
+        bootstrap_mode: "plain".to_string(),
+        env_overrides: collect_env_overrides(),
+        active_env_keys,
+        interpreter,
+    })
+}
+
+pub fn redacted_config_summary(workspace: &Workspace) -> OperationResult<ConfigSummary> {
+    let mut summary = config_summary(workspace)?;
+    for key in &mut summary.active_env_keys {
+        key.value = MASKED_ENV_VALUE.to_string();
+    }
+    Ok(summary)
+}
+
+fn read_active_env(workspace: &Workspace) -> Option<String> {
+    let repo = FsEnvironmentRepository::new(workspace.envs_dir());
+    repo.load_environment_config().ok().and_then(|c| c.active)
+}
+
+pub fn resolve_env_diagnostics(envs_dir: &Path) -> (Vec<EnvVarView>, InterpreterView) {
+    let pairs = resolve_active_env(envs_dir);
+    let sensitive_parent_values = sensitive_parent_values();
+    let program = python_program();
+    let path = resolve_interpreter(program, &pairs).map(|p| p.display().to_string());
+
+    let keys = pairs
+        .into_iter()
+        .map(|(key, value)| {
+            let value = if should_mask_resolved_env_value(&key, &value, &sensitive_parent_values) {
+                MASKED_ENV_VALUE.to_string()
+            } else {
+                value
+            };
+            EnvVarView { key, value }
+        })
+        .collect();
+
+    (
+        keys,
+        InterpreterView {
+            program: program.to_string(),
+            path,
+        },
+    )
+}
+
+pub fn mask_env_display_value(key: &str, value: String) -> String {
+    if should_mask_env_value(key, &value) {
+        MASKED_ENV_VALUE.to_string()
+    } else {
+        value
+    }
+}
+
+fn should_mask_resolved_env_value(
+    key: &str,
+    value: &str,
+    sensitive_parent_values: &[String],
+) -> bool {
+    should_mask_env_value(key, value)
+        || (!value.is_empty() && sensitive_parent_values.iter().any(|secret| secret == value))
+}
+
+fn sensitive_parent_values() -> Vec<String> {
+    env::vars()
+        .filter_map(|(key, value)| {
+            if is_sensitive_key(&key) && !value.is_empty() {
+                Some(value)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+pub fn collect_env_overrides() -> BTreeMap<String, String> {
+    let names = env_override_names();
+    let mut out = BTreeMap::new();
+    for name in names {
+        if let Ok(value) = env::var(name) {
+            out.insert(name.to_string(), mask_env_display_value(name, value));
+        }
+    }
+    out
+}
+
+pub fn env_override_names() -> [&'static str; 8] {
+    [
+        "OMAKURE_SCRIPTS_DIR",
+        "OMAKURE_REPO",
+        "REPO",
+        "VERSION",
+        "OVERTURE_SCRIPTS_DIR",
+        "OVERTURE_REPO",
+        "CLOUD_MGMT_SCRIPTS_DIR",
+        "CLOUD_MGMT_REPO",
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn write_active_env(dir: &Path, conf_name: &str, contents: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join(conf_name), contents).unwrap();
+        fs::write(dir.join("active"), format!("{}\n", conf_name)).unwrap();
+    }
+
+    #[test]
+    fn config_summary_serializes_full_contract() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = Workspace::new(tmp.path().to_path_buf());
+        workspace.ensure_layout().unwrap();
+
+        let payload = config_summary(&workspace).unwrap();
+
+        assert_eq!(payload.version, app_meta::APP_VERSION);
+        assert_eq!(
+            payload.workspace_root,
+            workspace.root().display().to_string()
+        );
+        assert_eq!(payload.bootstrap_mode, "plain");
+        assert_eq!(payload.interpreter.program, python_program());
+    }
+
+    #[test]
+    fn redacted_config_summary_masks_all_active_env_values() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = Workspace::new(tmp.path().to_path_buf());
+        workspace.ensure_layout().unwrap();
+        write_active_env(workspace.envs_dir(), "dev.conf", "HOST=localhost\n");
+
+        let payload = redacted_config_summary(&workspace).unwrap();
+
+        assert_eq!(payload.active_env_keys[0].key, "HOST");
+        assert_eq!(payload.active_env_keys[0].value, MASKED_ENV_VALUE);
+    }
+
+    #[test]
+    fn resolve_env_diagnostics_masks_sensitive_values() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let envs = tmp.path().join("envs");
+        write_active_env(
+            &envs,
+            "dev.conf",
+            "HOST=localhost\nAPI_KEY=supersecret123\n",
+        );
+
+        let (keys, _interp) = resolve_env_diagnostics(&envs);
+
+        assert_eq!(keys[0].value, "localhost");
+        assert_eq!(keys[1].value, MASKED_ENV_VALUE);
+        assert!(keys.iter().all(|kv| kv.value != "supersecret123"));
+    }
+
+    #[test]
+    fn resolve_env_diagnostics_masks_parent_sourced_secret_value() {
+        let _guard = env_lock();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let envs = tmp.path().join("envs");
+        env::set_var("AWS_SECRET_ACCESS_KEY", "parent-secret-value");
+        write_active_env(&envs, "dev.conf", "PLAIN=$AWS_SECRET_ACCESS_KEY\n");
+
+        let (keys, _interp) = resolve_env_diagnostics(&envs);
+
+        env::remove_var("AWS_SECRET_ACCESS_KEY");
+        assert_eq!(keys[0].key, "PLAIN");
+        assert_eq!(keys[0].value, MASKED_ENV_VALUE);
+    }
+
+    #[test]
+    fn collect_env_overrides_masks_credential_values() {
+        let _guard = env_lock();
+        env::set_var(
+            "OMAKURE_REPO",
+            "https://user:secret@example.invalid/repo.git",
+        );
+        let overrides = collect_env_overrides();
+        env::remove_var("OMAKURE_REPO");
+
+        assert_eq!(
+            overrides.get("OMAKURE_REPO"),
+            Some(&MASKED_ENV_VALUE.to_string())
+        );
+    }
+}

--- a/src/operations/core.rs
+++ b/src/operations/core.rs
@@ -238,6 +238,10 @@ pub fn list_traces(
 }
 
 pub fn queue_stats(workspace: &Workspace) -> OperationResult<RunStats> {
+    run_stats(workspace)
+}
+
+pub fn run_stats(workspace: &Workspace) -> OperationResult<RunStats> {
     let conn = runs::open(workspace).map_err(io_error_string)?;
     runs::stats(&conn).map_err(io_error_string)
 }

--- a/src/operations/core.rs
+++ b/src/operations/core.rs
@@ -1,0 +1,769 @@
+use crate::adapters::workspace_repository::FsWorkspaceRepository;
+use crate::app_meta;
+use crate::ports::ScriptRepository;
+use crate::runs::{
+    self, EnqueueOptions, RunFilters, RunRow, RunState, RunStateSet, RunStats, TraceLevel, TraceRow,
+};
+use crate::runtime::script_extensions;
+use crate::workspace::Workspace;
+use serde::{Deserialize, Serialize};
+use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
+
+use super::{OperationError, OperationErrorCode, OperationResult};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceSummary {
+    pub version: String,
+    pub workspace_root: PathBuf,
+    pub scripts_root: PathBuf,
+    pub omakure_dir: PathBuf,
+    pub history_dir: PathBuf,
+    pub workspace_config: PathBuf,
+    pub envs_dir: PathBuf,
+    pub envs_active_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ListScriptsRequest {
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScriptSummary {
+    pub absolute_path: String,
+    pub relative_path: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub field_count: usize,
+    pub schema_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DescribeScriptRequest {
+    pub script: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScriptDescription {
+    pub absolute_path: String,
+    pub relative_path: String,
+    pub schema: ScriptSchema,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScriptSchema {
+    pub name: String,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub fields: Vec<ScriptField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScriptField {
+    pub name: String,
+    pub prompt: Option<String>,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub order: u32,
+    pub required: bool,
+    pub arg: Option<String>,
+    pub default: Option<String>,
+    pub choices: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ListRunsRequest {
+    pub script: Option<String>,
+    pub actor: Option<String>,
+    pub since_ms: Option<i64>,
+    pub until_ms: Option<i64>,
+    pub success: Option<bool>,
+    pub limit: Option<i64>,
+    pub states: Vec<String>,
+    pub state_set: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShowRunRequest {
+    pub run_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListTracesRequest {
+    pub run_id: String,
+    pub level: Option<String>,
+    pub since_sequence: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnqueueRunRequest {
+    pub script: String,
+    pub args: Vec<String>,
+    pub run_id: Option<String>,
+    pub actor: String,
+    pub reason: Option<String>,
+    pub priority: i64,
+    pub timeout_ms: Option<i64>,
+    pub parent_run_id: Option<String>,
+    pub cron_schedule_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CancelRunRequest {
+    pub run_id: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeadLetterRunRequest {
+    pub run_id: String,
+    pub reason: Option<String>,
+}
+
+pub fn workspace_summary(workspace: &Workspace) -> OperationResult<WorkspaceSummary> {
+    Ok(WorkspaceSummary {
+        version: app_meta::APP_VERSION.to_string(),
+        workspace_root: workspace.root().to_path_buf(),
+        scripts_root: workspace.scripts_root().to_path_buf(),
+        omakure_dir: workspace.omakure_dir().to_path_buf(),
+        history_dir: workspace.history_dir().to_path_buf(),
+        workspace_config: workspace.config_path().to_path_buf(),
+        envs_dir: workspace.envs_dir().to_path_buf(),
+        envs_active_path: workspace.envs_active_path().to_path_buf(),
+    })
+}
+
+pub fn list_scripts(
+    workspace: &Workspace,
+    request: ListScriptsRequest,
+) -> OperationResult<Vec<ScriptSummary>> {
+    let repo = FsWorkspaceRepository::new(workspace.scripts_root().to_path_buf());
+    let mut scripts = repo.list_scripts_recursive().map_err(io_error)?;
+    scripts.sort();
+    Ok(scripts
+        .into_iter()
+        .map(|script| build_script_summary(&repo, workspace.scripts_root(), script))
+        .filter(|entry| matches_all_tags(entry, &request.tags))
+        .collect())
+}
+
+pub fn describe_script(
+    workspace: &Workspace,
+    request: DescribeScriptRequest,
+) -> OperationResult<ScriptDescription> {
+    let path = resolve_script_path(&request.script, workspace.scripts_root())?;
+    let repo = FsWorkspaceRepository::new(workspace.scripts_root().to_path_buf());
+    let schema = repo
+        .read_schema(&path)
+        .map_err(|err| OperationError::new(OperationErrorCode::InvalidInput, err.to_string()))?;
+    let absolute_path = std::fs::canonicalize(&path)
+        .unwrap_or_else(|_| path.clone())
+        .to_string_lossy()
+        .to_string();
+    let relative_path = path
+        .strip_prefix(workspace.scripts_root())
+        .unwrap_or(&path)
+        .to_string_lossy()
+        .to_string();
+    Ok(ScriptDescription {
+        absolute_path,
+        relative_path,
+        schema: script_schema_from_domain(schema),
+    })
+}
+
+fn script_schema_from_domain(schema: crate::domain::Schema) -> ScriptSchema {
+    let mut fields: Vec<ScriptField> = schema
+        .fields
+        .into_iter()
+        .map(|field| ScriptField {
+            name: field.name,
+            prompt: field.prompt,
+            kind: field.kind,
+            order: field.order.unwrap_or(0),
+            required: field.required.unwrap_or(false),
+            arg: field.arg,
+            default: field.default,
+            choices: field.choices,
+        })
+        .collect();
+    fields.sort_by_key(|field| field.order);
+    ScriptSchema {
+        name: schema.name,
+        description: schema.description,
+        tags: schema.tags.unwrap_or_default(),
+        fields,
+    }
+}
+
+pub fn list_runs(workspace: &Workspace, request: ListRunsRequest) -> OperationResult<Vec<RunRow>> {
+    let states = resolve_states(&request.states, request.state_set.as_deref())?;
+    let filters = RunFilters {
+        script: request.script,
+        actor: request.actor,
+        since_ms: request.since_ms,
+        until_ms: request.until_ms,
+        success: request.success,
+        limit: request.limit,
+        states,
+    };
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    runs::query_runs(&conn, &filters).map_err(io_error_string)
+}
+
+pub fn show_run(workspace: &Workspace, request: ShowRunRequest) -> OperationResult<RunRow> {
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    match runs::get_run(&conn, &request.run_id).map_err(io_error_string)? {
+        Some(row) => Ok(row),
+        None => Err(OperationError::new(
+            OperationErrorCode::NotFound,
+            format!("run not found: {}", request.run_id),
+        )),
+    }
+}
+
+pub fn list_traces(
+    workspace: &Workspace,
+    request: ListTracesRequest,
+) -> OperationResult<Vec<TraceRow>> {
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    let level = match request.level.as_deref() {
+        Some(level) => Some(TraceLevel::from_str(level).map_err(invalid_input)?),
+        None => None,
+    };
+    runs::query_traces(&conn, &request.run_id, level, request.since_sequence)
+        .map_err(map_not_found_string)
+}
+
+pub fn queue_stats(workspace: &Workspace) -> OperationResult<RunStats> {
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    runs::stats(&conn).map_err(io_error_string)
+}
+
+pub fn enqueue_run(workspace: &Workspace, request: EnqueueRunRequest) -> OperationResult<RunRow> {
+    let path = resolve_script_path(&request.script, workspace.scripts_root())?;
+    let canonical = std::fs::canonicalize(&path).unwrap_or(path);
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    runs::enqueue(
+        &conn,
+        canonical.to_string_lossy().as_ref(),
+        &request.args,
+        EnqueueOptions {
+            run_id: request.run_id,
+            actor: request.actor,
+            reason: request.reason,
+            priority: request.priority,
+            timeout_ms: request.timeout_ms,
+            parent_run_id: request.parent_run_id,
+            cron_schedule_id: request.cron_schedule_id,
+            script_name: None,
+            omakure_version: app_meta::APP_VERSION.to_string(),
+            trigger: runs::RunTrigger::Manual,
+        },
+    )
+    .map_err(io_error_string)
+}
+
+pub fn cancel_run(workspace: &Workspace, request: CancelRunRequest) -> OperationResult<RunRow> {
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    require_run(&conn, &request.run_id)?;
+    runs::cancel(&conn, &request.run_id, request.reason, None).map_err(map_transition_error)
+}
+
+pub fn dead_letter_run(
+    workspace: &Workspace,
+    request: DeadLetterRunRequest,
+) -> OperationResult<RunRow> {
+    let conn = runs::open(workspace).map_err(io_error_string)?;
+    require_run(&conn, &request.run_id)?;
+    runs::dead_letter(&conn, &request.run_id, request.reason).map_err(map_transition_error)
+}
+
+fn build_script_summary(
+    repo: &FsWorkspaceRepository,
+    root: &Path,
+    script: PathBuf,
+) -> ScriptSummary {
+    let relative_path = script
+        .strip_prefix(root)
+        .unwrap_or(&script)
+        .to_string_lossy()
+        .to_string();
+    let absolute_path = std::fs::canonicalize(&script)
+        .unwrap_or_else(|_| script.clone())
+        .to_string_lossy()
+        .to_string();
+    match repo.read_schema(&script) {
+        Ok(schema) => ScriptSummary {
+            absolute_path,
+            relative_path,
+            name: Some(schema.name),
+            description: schema.description,
+            tags: schema.tags.unwrap_or_default(),
+            field_count: schema.fields.len(),
+            schema_error: None,
+        },
+        Err(err) => ScriptSummary {
+            absolute_path,
+            relative_path,
+            name: None,
+            description: None,
+            tags: Vec::new(),
+            field_count: 0,
+            schema_error: Some(err.to_string()),
+        },
+    }
+}
+
+fn matches_all_tags(entry: &ScriptSummary, required: &[String]) -> bool {
+    required
+        .iter()
+        .all(|tag| entry.tags.iter().any(|entry_tag| entry_tag == tag))
+}
+
+fn resolve_script_path(script: &str, scripts_root: &Path) -> OperationResult<PathBuf> {
+    if script.trim().is_empty() {
+        return Err(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            "script is required",
+        ));
+    }
+
+    let root = scripts_root.canonicalize().map_err(|err| {
+        OperationError::new(
+            OperationErrorCode::IoFailed,
+            format!("failed to canonicalize scripts root: {err}"),
+        )
+    })?;
+    let has_separator = script.contains('/') || script.contains('\\');
+    let path = PathBuf::from(script);
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            format!("script path escapes scripts root: {script}"),
+        ));
+    }
+    if path.is_absolute() && !path.starts_with(&root) {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            format!("script path escapes scripts root: {script}"),
+        ));
+    }
+    let candidate = if path.is_absolute() {
+        path
+    } else if has_separator {
+        root.join(path)
+    } else {
+        root.join(script)
+    };
+    resolve_with_extensions(candidate, &root)
+}
+
+fn resolve_with_extensions(path: PathBuf, scripts_root: &Path) -> OperationResult<PathBuf> {
+    if path.exists() {
+        if path.is_file() {
+            return canonical_script_path(&path, scripts_root);
+        }
+        return Err(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            format!("script is not a file: {}", path.display()),
+        ));
+    }
+    if path.extension().is_some() {
+        return Err(OperationError::new(
+            OperationErrorCode::NotFound,
+            format!("script not found: {}", path.display()),
+        ));
+    }
+    for ext in script_extensions() {
+        let mut candidate = path.clone();
+        candidate.set_extension(ext);
+        if candidate.is_file() {
+            return canonical_script_path(&candidate, scripts_root);
+        }
+    }
+    Err(OperationError::new(
+        OperationErrorCode::NotFound,
+        format!("script not found: {}", path.display()),
+    ))
+}
+
+fn canonical_script_path(path: &Path, scripts_root: &Path) -> OperationResult<PathBuf> {
+    let canonical = path.canonicalize().map_err(|err| {
+        OperationError::new(
+            OperationErrorCode::IoFailed,
+            format!("failed to canonicalize script path: {err}"),
+        )
+    })?;
+    if canonical.starts_with(scripts_root) {
+        Ok(canonical)
+    } else {
+        Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            format!("script path escapes scripts root: {}", path.display()),
+        ))
+    }
+}
+
+fn resolve_states(states: &[String], state_set: Option<&str>) -> OperationResult<Vec<RunState>> {
+    if !states.is_empty() && state_set.is_some() {
+        return Err(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            "state and state_set are mutually exclusive",
+        ));
+    }
+    if let Some(set) = state_set {
+        return RunStateSet::from_str(set)
+            .map(|set| set.to_states())
+            .map_err(invalid_input);
+    }
+    if !states.is_empty() {
+        return states
+            .iter()
+            .map(|state| RunState::from_str(state).map_err(invalid_input))
+            .collect();
+    }
+    Ok(RunStateSet::Terminal.to_states())
+}
+
+fn require_run(conn: &rusqlite::Connection, run_id: &str) -> OperationResult<()> {
+    match runs::get_run(conn, run_id).map_err(io_error_string)? {
+        Some(_) => Ok(()),
+        None => Err(OperationError::new(
+            OperationErrorCode::NotFound,
+            format!("run not found: {run_id}"),
+        )),
+    }
+}
+
+fn map_transition_error(message: String) -> OperationError {
+    if message.contains("terminal state") || message.contains("only failed or timed_out") {
+        OperationError::new(OperationErrorCode::Conflict, message)
+    } else {
+        OperationError::new(OperationErrorCode::IoFailed, message)
+    }
+}
+
+fn map_not_found_string(message: String) -> OperationError {
+    if message.starts_with("not_found") {
+        OperationError::new(OperationErrorCode::NotFound, message)
+    } else {
+        OperationError::new(OperationErrorCode::IoFailed, message)
+    }
+}
+
+fn invalid_input(message: String) -> OperationError {
+    OperationError::new(OperationErrorCode::InvalidInput, message)
+}
+
+fn io_error(err: impl std::error::Error) -> OperationError {
+    OperationError::new(OperationErrorCode::IoFailed, err.to_string())
+}
+
+fn io_error_string(message: String) -> OperationError {
+    OperationError::new(OperationErrorCode::IoFailed, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runs::{RunCompletion, RunState};
+    use tempfile::TempDir;
+
+    fn workspace_in(dir: &TempDir) -> Workspace {
+        let ws = Workspace::new(dir.path().to_path_buf());
+        ws.ensure_layout().unwrap();
+        ws
+    }
+
+    fn write_script(root: &Path, path: &str, tags: &[&str]) {
+        let tags_json = if tags.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ",\"Tags\":[{}]",
+                tags.iter()
+                    .map(|tag| format!("\"{tag}\""))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )
+        };
+        let script = root.join(path);
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(
+            script,
+            format!(
+                "#!/usr/bin/env bash\n# OMAKURE_SCHEMA_START\n# {{\"Name\":\"{path}\",\"Fields\":[]{tags_json}}}\n# OMAKURE_SCHEMA_END\necho ok\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn workspace_summary_returns_operation_ready_paths() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+
+        let summary = workspace_summary(&ws).unwrap();
+
+        assert_eq!(summary.workspace_root, ws.root());
+        assert_eq!(summary.omakure_dir, ws.omakure_dir());
+        assert_eq!(summary.history_dir, ws.history_dir());
+    }
+
+    #[test]
+    fn list_scripts_filters_by_tags_and_preserves_schema_errors() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+        write_script(ws.scripts_root(), "deploy.sh", &["ops"]);
+        write_script(ws.scripts_root(), "other.sh", &["misc"]);
+        std::fs::write(ws.scripts_root().join("broken.sh"), "#!/usr/bin/env bash\n").unwrap();
+
+        let entries = list_scripts(
+            &ws,
+            ListScriptsRequest {
+                tags: vec!["ops".into()],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path, "deploy.sh");
+    }
+
+    #[test]
+    fn describe_script_returns_schema_payload() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+        write_script(ws.scripts_root(), "deploy.sh", &["ops"]);
+
+        let desc = describe_script(
+            &ws,
+            DescribeScriptRequest {
+                script: "deploy".into(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(desc.relative_path, "deploy.sh");
+        assert_eq!(desc.schema.tags, vec!["ops"]);
+    }
+
+    #[test]
+    fn script_resolution_rejects_absolute_paths_outside_workspace() {
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+        write_script(outside.path(), "outside.sh", &[]);
+
+        let err = enqueue_run(
+            &ws,
+            EnqueueRunRequest {
+                script: outside
+                    .path()
+                    .join("outside.sh")
+                    .to_string_lossy()
+                    .to_string(),
+                args: Vec::new(),
+                run_id: None,
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::UnsafePath);
+    }
+
+    #[test]
+    fn script_resolution_rejects_parent_traversal() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+
+        let err = describe_script(
+            &ws,
+            DescribeScriptRequest {
+                script: "../outside.sh".into(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::UnsafePath);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn script_resolution_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+        write_script(outside.path(), "outside.sh", &[]);
+        symlink(
+            outside.path().join("outside.sh"),
+            ws.scripts_root().join("escape.sh"),
+        )
+        .unwrap();
+
+        let err = describe_script(
+            &ws,
+            DescribeScriptRequest {
+                script: "escape.sh".into(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::UnsafePath);
+    }
+
+    #[test]
+    fn enqueue_list_show_cancel_and_stats_share_runs_state_machine() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+        write_script(ws.scripts_root(), "job.sh", &[]);
+
+        let row = enqueue_run(
+            &ws,
+            EnqueueRunRequest {
+                script: "job".into(),
+                args: vec!["--x".into()],
+                run_id: Some("rid-op".into()),
+                actor: "agent".into(),
+                reason: Some("test".into()),
+                priority: 5,
+                timeout_ms: Some(1000),
+                parent_run_id: None,
+                cron_schedule_id: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(row.state, RunState::Queued);
+
+        let rows = list_runs(
+            &ws,
+            ListRunsRequest {
+                state_set: Some("all".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+
+        let shown = show_run(
+            &ws,
+            ShowRunRequest {
+                run_id: "rid-op".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(shown.actor, "agent");
+
+        let cancelled = cancel_run(
+            &ws,
+            CancelRunRequest {
+                run_id: "rid-op".into(),
+                reason: Some("stop".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(cancelled.state, RunState::Cancelled);
+
+        let stats = queue_stats(&ws).unwrap();
+        assert_eq!(stats.total, 1);
+    }
+
+    #[test]
+    fn dead_letter_requires_existing_failed_run() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+        write_script(ws.scripts_root(), "job.sh", &[]);
+        let conn = runs::open(&ws).unwrap();
+        let row = runs::start_inline(
+            &conn,
+            ws.scripts_root().join("job.sh").to_string_lossy().as_ref(),
+            &[],
+            "worker:test",
+            EnqueueOptions {
+                run_id: Some("rid-fail".into()),
+                actor: "agent".into(),
+                reason: None,
+                priority: 0,
+                timeout_ms: None,
+                parent_run_id: None,
+                cron_schedule_id: None,
+                script_name: None,
+                omakure_version: app_meta::APP_VERSION.to_string(),
+                trigger: runs::RunTrigger::Manual,
+            },
+        )
+        .unwrap();
+        runs::fail(
+            &conn,
+            &row.run_id,
+            RunCompletion {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(1),
+                success: false,
+                error: Some("boom".into()),
+            },
+        )
+        .unwrap();
+
+        let dead = dead_letter_run(
+            &ws,
+            DeadLetterRunRequest {
+                run_id: "rid-fail".into(),
+                reason: Some("triaged".into()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(dead.state, RunState::DeadLetter);
+    }
+
+    #[test]
+    fn list_traces_reports_missing_run_as_not_found() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+
+        let err = list_traces(
+            &ws,
+            ListTracesRequest {
+                run_id: "missing".into(),
+                level: Some("debug".into()),
+                since_sequence: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::NotFound);
+    }
+
+    #[test]
+    fn invalid_state_filter_is_operation_error() {
+        let dir = TempDir::new().unwrap();
+        let ws = workspace_in(&dir);
+
+        let err = list_runs(
+            &ws,
+            ListRunsRequest {
+                states: vec!["bad".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::InvalidInput);
+    }
+}

--- a/src/operations/doctor.rs
+++ b/src/operations/doctor.rs
@@ -1,0 +1,194 @@
+use crate::adapters::system_checks::{
+    ensure_bash_installed, ensure_git_installed, ensure_jq_installed, ensure_powershell_installed,
+    ensure_python_installed,
+};
+use crate::adapters::workspace_repository::FsWorkspaceRepository;
+use crate::ports::ScriptRepository;
+use crate::workspace::Workspace;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::OperationResult;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DoctorReport {
+    pub ok: bool,
+    pub dependencies: Vec<DoctorCheck>,
+    pub workspace_paths: Vec<WorkspacePathCheck>,
+    pub schemas: SchemaCheckReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DoctorCheck {
+    pub label: String,
+    pub required: bool,
+    pub ok: bool,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspacePathCheck {
+    pub label: String,
+    pub path: String,
+    pub exists: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaCheckReport {
+    pub total: usize,
+    pub parsed: usize,
+    pub failures: Vec<SchemaFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaFailure {
+    pub path: PathBuf,
+    pub error: String,
+}
+
+pub fn doctor_report(workspace: &Workspace) -> OperationResult<DoctorReport> {
+    let dependencies = vec![
+        required_check("git", ensure_git_installed()),
+        required_check("bash", ensure_bash_installed()),
+        required_check("jq", ensure_jq_installed()),
+        optional_check("powershell", ensure_powershell_installed()),
+        optional_check("python", ensure_python_installed()),
+    ];
+    let workspace_paths = vec![
+        workspace_path("workspace_root", workspace.root()),
+        workspace_path("omakure_dir", workspace.omakure_dir()),
+        workspace_path("history_dir", workspace.history_dir()),
+        workspace_path("workspace_config", workspace.config_path()),
+    ];
+    let schemas = check_schemas(workspace.scripts_root());
+    let ok = dependencies
+        .iter()
+        .filter(|check| check.required)
+        .all(|check| check.ok);
+    Ok(DoctorReport {
+        ok,
+        dependencies,
+        workspace_paths,
+        schemas,
+    })
+}
+
+pub fn check_schemas(root: &Path) -> SchemaCheckReport {
+    let repo = FsWorkspaceRepository::new(root.to_path_buf());
+    let scripts = match repo.list_scripts_recursive() {
+        Ok(s) => s,
+        Err(_) => {
+            return SchemaCheckReport {
+                total: 0,
+                parsed: 0,
+                failures: Vec::new(),
+            }
+        }
+    };
+    let total = scripts.len();
+    let mut failures = Vec::new();
+    for script in scripts {
+        if let Err(err) = repo.read_schema(&script) {
+            let rel = script.strip_prefix(root).unwrap_or(&script).to_path_buf();
+            failures.push(SchemaFailure {
+                path: rel,
+                error: err.to_string(),
+            });
+        }
+    }
+    SchemaCheckReport {
+        total,
+        parsed: total - failures.len(),
+        failures,
+    }
+}
+
+fn required_check<E: std::fmt::Display>(label: &str, result: Result<(), E>) -> DoctorCheck {
+    dependency_check(label, true, result)
+}
+
+fn optional_check<E: std::fmt::Display>(label: &str, result: Result<(), E>) -> DoctorCheck {
+    dependency_check(label, false, result)
+}
+
+fn dependency_check<E: std::fmt::Display>(
+    label: &str,
+    required: bool,
+    result: Result<(), E>,
+) -> DoctorCheck {
+    match result {
+        Ok(()) => DoctorCheck {
+            label: label.to_string(),
+            required,
+            ok: true,
+            message: None,
+        },
+        Err(err) => DoctorCheck {
+            label: label.to_string(),
+            required,
+            ok: false,
+            message: Some(err.to_string()),
+        },
+    }
+}
+
+fn workspace_path(label: &str, path: &Path) -> WorkspacePathCheck {
+    WorkspacePathCheck {
+        label: label.to_string(),
+        path: path.display().to_string(),
+        exists: path.exists(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn check_schemas_reports_parseable_and_failures() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::write(
+            root.join("good.sh"),
+            "#!/bin/bash\n# OMAKURE_SCHEMA_START\n# {\"Name\": \"Good\", \"Fields\": []}\n# OMAKURE_SCHEMA_END\necho ok\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("broken.sh"),
+            "#!/bin/bash\n# OMAKURE_SCHEMA_START\n# {\"Name\": \"Broken\"}\necho still open\n",
+        )
+        .unwrap();
+
+        let report = check_schemas(root);
+
+        assert_eq!(report.total, 2);
+        assert_eq!(report.parsed, 1);
+        assert_eq!(report.failures[0].path, PathBuf::from("broken.sh"));
+    }
+
+    #[test]
+    fn check_schemas_empty_workspace_reports_zero() {
+        let tmp = TempDir::new().unwrap();
+        let report = check_schemas(tmp.path());
+        assert_eq!(report.total, 0);
+        assert_eq!(report.parsed, 0);
+        assert!(report.failures.is_empty());
+    }
+
+    #[test]
+    fn doctor_report_contains_workspace_and_schema_sections() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = Workspace::new(tmp.path().to_path_buf());
+        workspace.ensure_layout().unwrap();
+
+        let report = doctor_report(&workspace).unwrap();
+
+        assert!(report
+            .workspace_paths
+            .iter()
+            .any(|path| path.label == "workspace_root"));
+        assert_eq!(report.schemas.total, 0);
+    }
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,5 +1,9 @@
 pub mod battery;
+pub mod config;
 pub mod core;
+pub mod doctor;
+pub mod scripts;
+pub mod search;
 
 use serde::Serialize;
 use std::fmt;

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,4 +1,5 @@
 pub mod battery;
+pub mod core;
 
 use serde::Serialize;
 use std::fmt;
@@ -19,6 +20,7 @@ pub enum OperationErrorCode {
     GitFailed,
     IoFailed,
     RegistryInvalid,
+    PayloadTooLarge,
 }
 
 impl OperationErrorCode {
@@ -35,6 +37,7 @@ impl OperationErrorCode {
             Self::GitFailed => "git_failed",
             Self::IoFailed => "io_failed",
             Self::RegistryInvalid => "registry_invalid",
+            Self::PayloadTooLarge => "payload_too_large",
         }
     }
 }
@@ -80,6 +83,7 @@ mod tests {
             (OperationErrorCode::GitFailed, "git_failed"),
             (OperationErrorCode::IoFailed, "io_failed"),
             (OperationErrorCode::RegistryInvalid, "registry_invalid"),
+            (OperationErrorCode::PayloadTooLarge, "payload_too_large"),
         ];
 
         for (code, expected) in cases {

--- a/src/operations/scripts.rs
+++ b/src/operations/scripts.rs
@@ -1,0 +1,385 @@
+use crate::adapters::workspace_repository::FsWorkspaceRepository;
+use crate::ports::{ScriptRepository, WorkspaceEntryKind};
+use crate::runtime::script_kind;
+use crate::workspace::Workspace;
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use super::{OperationError, OperationErrorCode, OperationResult};
+
+pub const MAX_SCRIPT_CONTENT_BYTES: u64 = 1024 * 1024;
+pub const MAX_TREE_ENTRIES: usize = 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListTreeRequest {
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadScriptContentRequest {
+    pub script: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeEntry {
+    pub name: String,
+    pub relative_path: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScriptContent {
+    pub absolute_path: String,
+    pub relative_path: String,
+    pub content: String,
+    pub size_bytes: u64,
+}
+
+pub fn list_tree(
+    workspace: &Workspace,
+    request: ListTreeRequest,
+) -> OperationResult<Vec<TreeEntry>> {
+    let root = canonical_scripts_root(workspace)?;
+    let dir = resolve_workspace_path(request.path.as_deref().unwrap_or(""), &root)?;
+    if !dir.is_dir() {
+        return Err(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            "tree path is not a directory",
+        ));
+    }
+
+    let repo = FsWorkspaceRepository::new(root.clone());
+    let entries = repo.list_entries(&dir).map_err(io_error)?;
+    if entries.len() > MAX_TREE_ENTRIES {
+        return Err(OperationError::new(
+            OperationErrorCode::PayloadTooLarge,
+            format!("tree listing exceeds {MAX_TREE_ENTRIES} entries"),
+        ));
+    }
+    Ok(entries
+        .into_iter()
+        .map(|entry| {
+            let relative_path = entry
+                .path
+                .strip_prefix(&root)
+                .unwrap_or(&entry.path)
+                .to_string_lossy()
+                .to_string();
+            let name = entry
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("")
+                .to_string();
+            let kind = match entry.kind {
+                WorkspaceEntryKind::Directory => "directory",
+                WorkspaceEntryKind::Script => "script",
+            }
+            .to_string();
+            TreeEntry {
+                name,
+                relative_path,
+                kind,
+            }
+        })
+        .collect())
+}
+
+pub fn read_script_content(
+    workspace: &Workspace,
+    request: ReadScriptContentRequest,
+) -> OperationResult<ScriptContent> {
+    let root = canonical_scripts_root(workspace)?;
+    let path = resolve_workspace_path(&request.script, &root)?;
+    if !path.is_file() {
+        return Err(OperationError::new(
+            OperationErrorCode::InvalidInput,
+            "script is not a file",
+        ));
+    }
+    if script_kind(&path).is_none() {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsupportedScript,
+            "unsupported script type",
+        ));
+    }
+    let mut file = open_script_file(&path, &root)?;
+    let metadata = file.metadata().map_err(io_error)?;
+    if metadata.len() > MAX_SCRIPT_CONTENT_BYTES {
+        return Err(OperationError::new(
+            OperationErrorCode::PayloadTooLarge,
+            format!("script content exceeds {} bytes", MAX_SCRIPT_CONTENT_BYTES),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut bytes).map_err(io_error)?;
+    if bytes.contains(&0) {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsupportedScript,
+            "script content is binary",
+        ));
+    }
+    let content = String::from_utf8(bytes).map_err(|_| {
+        OperationError::new(
+            OperationErrorCode::UnsupportedScript,
+            "script content is not valid UTF-8",
+        )
+    })?;
+    let relative_path = path
+        .strip_prefix(&root)
+        .unwrap_or(&path)
+        .to_string_lossy()
+        .to_string();
+    Ok(ScriptContent {
+        absolute_path: path.to_string_lossy().to_string(),
+        relative_path,
+        size_bytes: metadata.len(),
+        content,
+    })
+}
+
+fn canonical_scripts_root(workspace: &Workspace) -> OperationResult<PathBuf> {
+    workspace.scripts_root().canonicalize().map_err(|err| {
+        OperationError::new(
+            OperationErrorCode::IoFailed,
+            format!("failed to canonicalize scripts root: {err}"),
+        )
+    })
+}
+
+fn resolve_workspace_path(path: &str, root: &Path) -> OperationResult<PathBuf> {
+    if path.starts_with('/') || path.starts_with('\\') {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            "path escapes scripts root",
+        ));
+    }
+    let raw = path.trim_start_matches('/');
+    let path = PathBuf::from(raw);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            "path escapes scripts root",
+        ));
+    }
+    if path.components().any(is_hidden_metadata_component) {
+        return Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            "path targets hidden Omakure metadata",
+        ));
+    }
+    let candidate = root.join(path);
+    let canonical = candidate.canonicalize().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            OperationError::new(
+                OperationErrorCode::NotFound,
+                format!("path not found: {raw}"),
+            )
+        } else {
+            io_error(err)
+        }
+    })?;
+    if canonical.starts_with(root) {
+        Ok(canonical)
+    } else {
+        Err(OperationError::new(
+            OperationErrorCode::UnsafePath,
+            "path escapes scripts root",
+        ))
+    }
+}
+
+fn open_script_file(path: &Path, root: &Path) -> OperationResult<std::fs::File> {
+    let file = open_no_follow(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let fd_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+        if let Ok(opened) = fd_path.canonicalize() {
+            if !opened.starts_with(root) {
+                return Err(OperationError::new(
+                    OperationErrorCode::UnsafePath,
+                    "path escapes scripts root",
+                ));
+            }
+        }
+    }
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn open_no_follow(path: &Path) -> OperationResult<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(0o400000)
+        .open(path)
+        .map_err(io_error)
+}
+
+#[cfg(not(unix))]
+fn open_no_follow(path: &Path) -> OperationResult<std::fs::File> {
+    std::fs::File::open(path).map_err(io_error)
+}
+
+fn is_hidden_metadata_component(component: Component<'_>) -> bool {
+    matches!(
+        component,
+        Component::Normal(name)
+            if name == ".omakure" || name == ".history" || name == ".git"
+    )
+}
+
+fn io_error(err: impl std::error::Error) -> OperationError {
+    OperationError::new(OperationErrorCode::IoFailed, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn workspace_in(dir: &TempDir) -> Workspace {
+        let workspace = Workspace::new(dir.path().to_path_buf());
+        workspace.ensure_layout().unwrap();
+        workspace
+    }
+
+    #[test]
+    fn list_tree_honors_nested_omakureignore() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::create_dir_all(workspace.scripts_root().join("scripts/hidden")).unwrap();
+        std::fs::write(
+            workspace.scripts_root().join("scripts/.omakureignore"),
+            "hidden/\n",
+        )
+        .unwrap();
+        std::fs::write(
+            workspace.scripts_root().join("scripts/show.sh"),
+            "#!/bin/sh\n",
+        )
+        .unwrap();
+        std::fs::write(
+            workspace.scripts_root().join("scripts/hidden/nope.sh"),
+            "#!/bin/sh\n",
+        )
+        .unwrap();
+
+        let entries = list_tree(
+            &workspace,
+            ListTreeRequest {
+                path: Some("scripts".into()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path, "scripts/show.sh");
+    }
+
+    #[test]
+    fn read_script_content_rejects_parent_traversal() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let err = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "../outside.sh".into(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::UnsafePath);
+    }
+
+    #[test]
+    fn read_script_content_rejects_absolute_paths_before_trimming() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        let err = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "/tmp/outside.sh".into(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::UnsafePath);
+    }
+
+    #[test]
+    fn list_tree_rejects_too_many_entries() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        for idx in 0..=MAX_TREE_ENTRIES {
+            std::fs::write(
+                workspace.scripts_root().join(format!("script-{idx}.sh")),
+                "#!/bin/sh\n",
+            )
+            .unwrap();
+        }
+
+        let err = list_tree(&workspace, ListTreeRequest { path: None }).unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::PayloadTooLarge);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_script_content_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::write(outside.path().join("outside.sh"), "#!/bin/sh\n").unwrap();
+        symlink(
+            outside.path().join("outside.sh"),
+            workspace.scripts_root().join("escape.sh"),
+        )
+        .unwrap();
+
+        let err = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "escape.sh".into(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::UnsafePath);
+    }
+
+    #[test]
+    fn read_script_content_returns_text_script() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::write(
+            workspace.scripts_root().join("ok.sh"),
+            "#!/bin/sh\necho ok\n",
+        )
+        .unwrap();
+
+        let content = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "ok.sh".into(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(content.relative_path, "ok.sh");
+        assert!(content.content.contains("echo ok"));
+    }
+}

--- a/src/operations/scripts.rs
+++ b/src/operations/scripts.rs
@@ -335,6 +335,83 @@ mod tests {
         assert_eq!(err.code, OperationErrorCode::PayloadTooLarge);
     }
 
+    #[test]
+    fn tree_and_content_reject_hidden_metadata_paths() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+
+        for path in [".omakure", ".history", ".git"] {
+            let tree_err = list_tree(
+                &workspace,
+                ListTreeRequest {
+                    path: Some(path.into()),
+                },
+            )
+            .unwrap_err();
+            assert_eq!(tree_err.code, OperationErrorCode::UnsafePath);
+
+            let content_err = read_script_content(
+                &workspace,
+                ReadScriptContentRequest {
+                    script: format!("{path}/secret.sh"),
+                },
+            )
+            .unwrap_err();
+            assert_eq!(content_err.code, OperationErrorCode::UnsafePath);
+        }
+    }
+
+    #[test]
+    fn read_script_content_rejects_oversized_scripts() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::write(
+            workspace.scripts_root().join("big.sh"),
+            vec![b'a'; MAX_SCRIPT_CONTENT_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let err = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "big.sh".into(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, OperationErrorCode::PayloadTooLarge);
+    }
+
+    #[test]
+    fn read_script_content_rejects_binary_and_invalid_utf8() {
+        let dir = TempDir::new().unwrap();
+        let workspace = workspace_in(&dir);
+        std::fs::write(
+            workspace.scripts_root().join("binary.sh"),
+            b"#!/bin/sh\n\0\n",
+        )
+        .unwrap();
+        std::fs::write(workspace.scripts_root().join("bad-utf8.sh"), [0xff, 0xfe]).unwrap();
+
+        let binary_err = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "binary.sh".into(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(binary_err.code, OperationErrorCode::UnsupportedScript);
+
+        let utf8_err = read_script_content(
+            &workspace,
+            ReadScriptContentRequest {
+                script: "bad-utf8.sh".into(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(utf8_err.code, OperationErrorCode::UnsupportedScript);
+    }
+
     #[cfg(unix)]
     #[test]
     fn read_script_content_rejects_symlink_escape() {

--- a/src/operations/search.rs
+++ b/src/operations/search.rs
@@ -1,0 +1,146 @@
+use crate::operations::core::ScriptSummary;
+use crate::search_index::{SearchIndex, SearchResult, SearchStatus};
+use crate::workspace::Workspace;
+use serde::{Deserialize, Serialize};
+use std::thread;
+use std::time::Duration;
+
+use super::{OperationError, OperationErrorCode, OperationResult};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchScriptsRequest {
+    pub query: String,
+    pub tags: Vec<String>,
+    pub refresh: bool,
+}
+
+pub fn search_scripts(
+    workspace: &Workspace,
+    request: SearchScriptsRequest,
+) -> OperationResult<Vec<ScriptSummary>> {
+    workspace.ensure_layout().map_err(io_error)?;
+
+    let index = SearchIndex::new(workspace.search_db_path());
+    if request.refresh {
+        index.start_background_rebuild(workspace.scripts_root().to_path_buf());
+        block_until_ready(&index);
+    }
+
+    let results = index
+        .query(&request.query)
+        .map_err(|err| OperationError::new(OperationErrorCode::IoFailed, err))?;
+
+    Ok(results
+        .into_iter()
+        .map(|result| to_summary(result, workspace.scripts_root()))
+        .filter(|entry| matches_all_tags(entry, &request.tags))
+        .collect())
+}
+
+fn to_summary(result: SearchResult, root: &std::path::Path) -> ScriptSummary {
+    let joined = if result.script_path.is_absolute() {
+        result.script_path.clone()
+    } else {
+        root.join(&result.script_path)
+    };
+    let absolute_path = std::fs::canonicalize(&joined)
+        .unwrap_or(joined)
+        .to_string_lossy()
+        .to_string();
+    let relative_path = result.script_path.to_string_lossy().to_string();
+    ScriptSummary {
+        absolute_path,
+        relative_path,
+        name: Some(result.display_name),
+        description: result.description,
+        tags: result.tags,
+        field_count: 0,
+        schema_error: result.schema_error,
+    }
+}
+
+fn matches_all_tags(entry: &ScriptSummary, required: &[String]) -> bool {
+    required
+        .iter()
+        .all(|tag| entry.tags.iter().any(|entry_tag| entry_tag == tag))
+}
+
+fn block_until_ready(index: &SearchIndex) {
+    for _ in 0..50 {
+        match index.status() {
+            SearchStatus::Ready { .. } | SearchStatus::Error(_) => return,
+            _ => thread::sleep(Duration::from_millis(100)),
+        }
+    }
+}
+
+fn io_error(err: impl std::error::Error) -> OperationError {
+    OperationError::new(OperationErrorCode::IoFailed, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_script(dir: &std::path::Path, name: &str, tags: &[&str]) {
+        let tags_json = if tags.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ",\"Tags\":[{}]",
+                tags.iter()
+                    .map(|tag| format!("\"{tag}\""))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )
+        };
+        std::fs::write(
+            dir.join(name),
+            format!(
+                "#!/usr/bin/env bash\n# OMAKURE_SCHEMA_START\n# {{\"Name\":\"{name}\",\"Description\":\"Ship\",\"Fields\":[]{tags_json}}}\n# OMAKURE_SCHEMA_END\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn search_scripts_refreshes_index_and_filters_tags() {
+        let dir = TempDir::new().unwrap();
+        let workspace = Workspace::new(dir.path().to_path_buf());
+        write_script(workspace.scripts_root(), "deploy.sh", &["ops"]);
+        write_script(workspace.scripts_root(), "noise.sh", &["other"]);
+
+        let results = search_scripts(
+            &workspace,
+            SearchScriptsRequest {
+                query: "deploy".into(),
+                tags: vec!["ops".into()],
+                refresh: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].relative_path, "deploy.sh");
+    }
+
+    #[test]
+    fn search_scripts_empty_query_returns_indexed_scripts() {
+        let dir = TempDir::new().unwrap();
+        let workspace = Workspace::new(dir.path().to_path_buf());
+        write_script(workspace.scripts_root(), "deploy.sh", &[]);
+
+        let results = search_scripts(
+            &workspace,
+            SearchScriptsRequest {
+                query: String::new(),
+                tags: Vec::new(),
+                refresh: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add the internal HTTP management API backed by shared operations
- expose workspace, script, run, queue, and Battery management endpoints
- update project documentation to reflect implemented behavior only

## Validation
- cargo test
- mise run lint